### PR TITLE
New IR Architecture

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -19,11 +19,9 @@ void debug_file_buffer(file_buffer* reader);
 void debug_print_symbol_table(hash_table* table);
 void debug_tokenize(file_buffer* buffer, hash_table* table);
 void debug_ast(java_parser* parser);
-void debug_shash_table(hash_table* table);
 void debug_java_symbol_lookup_table_no_collision_test(bool use_prime_size);
-void debug_ir_on_demand_imports(java_ir* ir);
+void debug_print_global_import(java_ir* ir);
 void debug_ir_global_names(java_ir* ir);
 void debug_ir_literal(java_ir* ir);
-void debug_print_member_initialization(java_ir* ir);
 
 #endif

--- a/ir-semantics.c
+++ b/ir-semantics.c
@@ -12,314 +12,44 @@ static const char* reserved_method_name_entry_point = "main";
 // reserved default architecture
 static const architecture default_arch = { .bits = ARCH_64_BIT };
 
-static void ctx_import(java_ir* ir, tree_node* node);
-static void ctx_class(java_ir* ir, tree_node* node);
-static void ctx_interface(java_ir* ir, tree_node* node);
-
 /**
  * Context Analysis Entry Point
  *
- * It will generate a SSA form of AST
 */
 void contextualize(java_ir* ir, architecture* arch, tree_node* compilation_unit)
 {
     // register architecture of current target
     ir->arch = arch ? arch : &default_arch;
 
-    // compilation unit does not have siblings
     tree_node* node = compilation_unit->first_child;
+    global_top_level* top;
 
-    // package
-    if (node && node->type == JNT_PKG_DECL)
-    {
-        /**
-         * TODO: handle pkg decl
-        */
-        node = node->next_sibling;
-    }
-
-    // imports
-    while (node && node->type == JNT_IMPORT_DECL)
-    {
-        ctx_import(ir, node);
-        node = node->next_sibling;
-    }
-
-    // top-levels
-    while (node && node->type == JNT_TOP_LEVEL)
-    {
-        // handle top level
-        if (node->first_child->type == JNT_CLASS_DECL)
-        {
-            ctx_class(ir, node);
-        }
-        else
-        {
-            ctx_interface(ir, node);
-        }
-
-        node = node->next_sibling;
-    }
+    // prepare definitions
+    def_global(ir, compilation_unit);
 
     /**
-     * TODO:
+     * now we have all defs in place, we can start generating code
      *
-     * resolve all external types
     */
-}
-
-/**
- * contextualize "import"
- *
- * import goes into global scope
- * on-demand import goes into separate global table
-*/
-static void ctx_import(java_ir* ir, tree_node* node)
-{
-    definition* desc = NULL;
-    hash_table* table = NULL;
-    // JNT_IMPORT_DECL -> Name -> Unit
-    tree_node* name = node->first_child;
-    tree_node* last_unit = NULL;
-    char* registered_name = NULL;
-    char* pkg_name = NULL;
-
-    if (!node->data->import.on_demand)
+    for (size_t i = 0; i < ir->tbl_global.bucket_size; i++)
     {
-        // last name unit is the import target
-        last_unit = name->last_child;
-        registered_name = t2s(last_unit->data->id.complex);
-    }
-
-    // construct package name list
-    pkg_name = name_unit_concat(name->first_child, last_unit);
-
-    // register the class name if applicable
-    if (registered_name)
-    {
-        table = lookup_global_scope(ir);
-        desc = new_definition(JNT_IMPORT_DECL);
-
-        // move the data and detach
-        desc->import.package_name = pkg_name;
-        pkg_name = NULL;
-
-        // name resolution must be unique
-        if (!lookup_register(ir, table, &registered_name, &desc, JAVA_E_MAX))
+        for (hash_pair* p = ir->tbl_global.bucket[i]; p != NULL; p = p->next)
         {
-            if (strcmp(pkg_name, HT_STR2DEF(table, registered_name)->import.package_name) == 0)
+            top = p->value;
+
+            if (!top) { continue; }
+
+            switch (top->type)
             {
-                ir_error(ir, JAVA_E_IMPORT_DUPLICATE);
-            }
-            else
-            {
-                ir_error(ir, JAVA_E_IMPORT_AMBIGUOUS);
+                case TOP_LEVEL_CLASS:
+                    walk_class(ir, top);
+                    break;
+                case TOP_LEVEL_INTERFACE:
+                    walk_interface(ir, top);
+                    break;
+                default:
+                    break;
             }
         }
     }
-    else
-    {
-        table = &ir->tbl_on_demand_packages;
-
-        /**
-         * on-demand import in ir is not needed to link to specifc symbol
-         * unless there is an ambiguity in AST that require this info to
-         * resolve
-         *
-         * so the table simply logs the package name so we can use it
-         * whenever necessary in ir, and in linker
-         *
-         * here: desc = NULL
-        */
-        lookup_register(ir, table, &pkg_name, &desc, JAVA_E_IMPORT_DUPLICATE);
-    }
-
-    // cleanup
-    free(registered_name);
-    free(pkg_name);
-    definition_delete(desc);
-}
-
-/**
- * contextualize "class declaration"
- *
- * this is a 2-pass parsing logic, because use of top level members does
- * not obey "def before use" rule; and since all definitions (including
- * local variables) will be flushed into global scope, so it is not safe
- * to use a dummy definition first then fill when reaching the def
- *
- * node: JNT_TOP_LEVEL
-*/
-static void ctx_class(java_ir* ir, tree_node* node)
-{
-    // register all definitions first
-    def_class(ir, node);
-
-    hash_table* table = lookup_global_scope(ir);
-    tree_node* part = NULL;
-    tree_node* declaration = NULL;
-    definition* desc = NULL;
-    cfg_worker* worker = NULL;
-    reference* lvalue;
-    reference* operand;
-    cfg_worker member_init_worker;
-
-    init_cfg_worker(&member_init_worker);
-
-    /**
-     * JNT_TOP_LEVEL
-     * |
-     * +--- JNT_CLASS_DECL
-     *      |
-     *      +--- JNT_CLASS_EXTENDS      <--- HERE
-     *      |    |
-     *      |    +--- Type
-     *      |
-     *      +--- JNT_CLASS_IMPLEMENTS
-     *      |    |
-     *      |    +--- JNT_INTERFACE_TYPE_LIST
-     *      |         |
-     *      |         +--- Type
-     *      |         |
-     *      |         +--- ...
-     *      |
-     *      +--- JNT_CLASS_BODY
-     *           |
-     *           +--- JNT_CLASS_BODY_DECL
-     *           |    |
-     *           |    +--- Type
-     *           |    |
-     *           |    +--- JNT_VAR_DECLARATORS | JNT_METHOD_DECL
-     *           |
-     *           +--- JNT_CLASS_BODY_DECL
-     *           |
-     *           +--- ...
-    */
-    part = node->first_child->first_child;
-
-    // locate JNT_CLASS_BODY
-    while (part && part->type != JNT_CLASS_BODY)
-    {
-        part = part->next_sibling;
-    }
-
-    // reach first JNT_CLASS_BODY_DECL
-    part = part->first_child;
-
-    // code generation
-    while (part)
-    {
-        /**
-         * TODO: IR code generation for:
-         * 1. static initializer
-         * 2. constructor
-         * 3. member variable initializer
-         * 4. method block
-        */
-
-        // reach content
-        declaration = part->first_child;
-
-        if (declaration->type == JNT_STATIC_INIT)
-        {
-            /**
-             * TODO: static initializer
-            */
-        }
-        else if (declaration->type == JNT_CTOR_DECL)
-        {
-            /**
-             * TODO: constructor
-            */
-        }
-        else if (declaration->type == JNT_TYPE)
-        {
-            if (declaration->next_sibling->type == JNT_VAR_DECLARATORS)
-            {
-                declaration = declaration->next_sibling->first_child;
-
-                // we only have global to lookup so no need to call use()
-                desc = t2d(table, declaration->data->declarator.id.complex);
-
-                // reach initializer
-                declaration = declaration->first_child;
-
-                // create variable data chunk ref
-                lvalue = new_reference(IR_ASN_REF_DEFINITION, desc);
-
-                if (declaration)
-                {
-                    // if has a child, then it is the initializer
-                    if (declaration->type == JNT_EXPRESSION)
-                    {
-                        // parse right side
-                        push_scope_worker(ir);
-                        walk_expression(ir, declaration);
-
-                        // prepare assignment code
-                        worker = get_scope_worker(ir);
-                        operand = new_reference(IR_ASN_REF_INSTRUCTION, worker->cur_blk->inst_last);
-
-                        // add assignment code
-                        cfg_worker_next_asn_strategy(TSW(ir), true);
-                        cfg_worker_execute(ir, worker, IROP_ASN, &lvalue, &operand, NULL);
-
-                        // cleanup
-                        delete_reference(operand);
-
-                        // merge code
-                        worker = pop_scope_worker(ir);
-                        cfg_worker_grow_with_graph(&member_init_worker, worker);
-                    }
-                    else if (declaration->type == JNT_ARRAY_INIT)
-                    {
-                        /**
-                         * TODO: array (of expression) init code
-                        */
-                    }
-                }
-                else
-                {
-                    /**
-                     * otherwise we insert a dummy code, indicate that
-                     * the variable is defined here and some initialization required
-                    */
-                    cfg_worker_execute(ir, &member_init_worker, IROP_INIT, &lvalue, NULL, NULL);
-                }
-
-                // cleanup
-                delete_reference(lvalue);
-            }
-            else if (declaration->next_sibling->type == JNT_METHOD_DECL)
-            {
-                /**
-                 * type
-                 * |
-                 * method declaration    <--- HERE
-                */
-                walk_method(ir, declaration->next_sibling);
-            }
-        }
-
-        part = part->next_sibling;
-    }
-
-    // cleanup
-    if (cfg_empty(member_init_worker.graph))
-    {
-        release_cfg_worker(&member_init_worker, NULL, NULL);
-    }
-    else
-    {
-        // no init, just need a memory chunk here
-        ir->code_member_init = new_cfg_container();
-        release_cfg_worker(&member_init_worker, ir->code_member_init, &ir->member_variables);
-    }
-}
-
-/**
- * TODO:contextualize "interface declaration"
-*/
-static void ctx_interface(java_ir* ir, tree_node* node)
-{
 }

--- a/main.c
+++ b/main.c
@@ -20,8 +20,8 @@ static char* test_paths[] = {
     // "./test/class-decl-1.txt",
     // "./test/interface-decl-1.txt",
 
-    // "./test/simple.txt",
-    "./test/ssa.txt",
+    "./test/simple.txt",
+    // "./test/ssa.txt",
 
     // "./test/general-no-block-and-statement.txt",
 
@@ -68,8 +68,7 @@ int main(int argc, char* argv[])
         if (compile(&compiler, &arch, test_paths[i]))
         {
             debug_ast(&compiler.context);
-            debug_ir_on_demand_imports(&compiler.ir);
-            debug_print_member_initialization(&compiler.ir);
+            debug_print_global_import(&compiler.ir);
             debug_ir_global_names(&compiler.ir);
             debug_ir_literal(&compiler.ir);
             debug_ir_lookup(&compiler.ir);

--- a/output/2024-03-13.txt
+++ b/output/2024-03-13.txt
@@ -1,0 +1,843 @@
+===== COMPILER RUNTIME REPORT =====
+Language version: 1
+Reserved word:
+    count: 50
+    memory: 4824 bytes
+    load factor: 14.16%
+    longest chain: 1
+Expression static data size: 1072 bytes
+Error static data size: 574 bytes
+===== END OF REPORT =====
+
+File 1: ./test/simple.txt
+all dominator sets:
+0: 0
+1: 0 1
+2: 2 0
+3: 0 3 1
+4: 0 4 1
+all DF sets:
+0:
+1:
+2: 1
+3:
+4: 3
+all dominator sets:
+0: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+1: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+2: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+3: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+4: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+5: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+6: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+7: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+8: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+9: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+10: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+11: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+12: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+13: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+14: 2 11 0 5 9 14 7 10 13 3 6 4 12 8 1
+all DF sets:
+0: 0
+1: 1
+2: 2
+3: 3
+4: 4
+5: 5
+6: 6
+7: 7
+8: 8
+9: 9
+10: 10
+11: 11
+12: 12
+13: 13
+14: 14
+all dominator sets:
+0: 0
+1: 0 1
+2: 2 0 6 4 1
+3: 0 3 4 1
+4: 0 4 1
+5: 0 4 5 1
+6: 0 6 4 1
+7: 0 7 6 4 1
+8: 0 6 4 8 1
+all DF sets:
+0:
+1: 1
+2: 3 1
+3:
+4: 1
+5: 3 6
+6: 3 1
+7: 2 8
+8: 2
+all dominator sets:
+0: 0
+1: 0 1
+2: 2 0 1
+3: 0 3 1
+4: 0 4 1
+5: 0 5 1
+6: 0 10 6 12 4 8 1
+7: 0 7 4 1
+8: 0 4 8 1
+9: 0 9 4 8 1
+10: 0 10 12 4 8 1
+11: 11 0 10 4 12 8 1
+12: 0 10 12 4 8 1
+all DF sets:
+0:
+1:
+2: 4
+3: 2
+4: 1
+5: 2 3
+6: 1
+7:
+8: 7 1
+9: 7 10
+10: 1
+11: 6 12
+12: 12 1
+all dominator sets:
+0: 0
+all DF sets:
+0:
+all dominator sets:
+0: 0
+all DF sets:
+0:
+all dominator sets:
+0: 0
+all DF sets:
+0:
+===== ABSTRACT SYNTAX TREE =====
+Compilation Unit
+  Package Declaration
+    Name
+      Unit: mypack
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: text
+      Unit: DecimalFormat
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: util
+      Unit: InputMismatchException
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: util
+      Unit: Scanner
+  Import Declaration (On-demand: true)
+    Name
+      Unit: somepackage
+  Top Level: No Modifier
+    Class Declaration: MyPackageClass
+      Class Extends
+        Class Type
+          Unit: C1
+      Class Implements
+        Interface Type List
+          Interface Type
+            Unit: C2
+          Interface Type
+            Unit: C3
+      Class Body
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_INT
+          Variable Declarators
+            Variable Declarator: r2
+              Expression
+                Primary
+                  1
+                Primary
+                  2
+                OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                Primary
+                  3
+                Primary
+                  4
+                Primary
+                  5
+                OP[9]: OPID_MUL -> JLT_SYM_ASTERISK "*"
+                OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                Primary
+                  6
+                Primary
+                  7
+                OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                OP[30]: OPID_TERNARY_2 -> JLT_SYM_COLON ":"
+                OP[29]: OPID_TERNARY_1 -> JLT_SYM_QUESTION "?"
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_INT
+          Variable Declarators
+            Variable Declarator: r3
+              Expression
+                Primary
+                  0
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_SHORT
+          Variable Declarators
+            Variable Declarator: r4
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_VOID
+          Method Declaration
+            Method Header: logic
+            Method Body
+              Block
+                Expression Statement
+                  Expression
+                    Primary
+                      1
+                    Primary
+                      2
+                    OP[28]: OPID_LOGIC_OR -> JLT_SYM_LOGIC_OR "||"
+                    Primary
+                      3
+                    Primary
+                      4
+                    OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                    OP[28]: OPID_LOGIC_OR -> JLT_SYM_LOGIC_OR "||"
+        Class Body Declaration: private
+          Type: JLT_RWD_INT
+          Method Declaration
+            Method Header: calc
+              Formal Parameter List
+                Formal Parameter: x
+                  Type: JLT_RWD_INT
+                Formal Parameter: y
+                  Type: JLT_RWD_INT
+                Formal Parameter: r2
+                  Type: JLT_RWD_SHORT
+            Method Body
+              Block
+                While Statement
+                  Expression
+                    Primary
+                      x
+                    Primary
+                      y
+                    OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                  Block
+                    If Statement
+                      Expression
+                        Primary
+                          4
+                        Primary
+                          9
+                        OP[22]: OPID_EQ -> JLT_SYM_RELATIONAL_EQUAL "=="
+                      Break Statement: (null)
+                    Expression Statement
+                      Expression
+                        Primary
+                          x
+                        OP[2]: OPID_POST_DEC -> JLT_SYM_DECREMENT "--"
+                    If Statement
+                      Expression
+                        Primary
+                          6
+                        Primary
+                          2
+                        OP[20]: OPID_GREAT_EQ -> JLT_SYM_GREATER_EQUAL ">="
+                      Block
+                        Continue Statement: (null)
+                If Statement
+                  Expression
+                    Primary
+                      2
+                    Primary
+                      1
+                    OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                  Block
+                    Expression Statement
+                      Expression
+                        Primary
+                          x
+                        Primary
+                          y
+                        OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                    Expression Statement
+                      Expression
+                        Primary
+                          r3
+                        Primary
+                          r2
+                        Primary
+                          6
+                        OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                        Primary
+                          y
+                        OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                        OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+                    Return Statement
+                      Expression
+                        Primary
+                          3
+                  If Statement
+                    Expression
+                      Primary
+                        r2
+                      Primary
+                        x
+                      OP[17]: OPID_LESS -> JLT_SYM_ANGLE_BRACKET_OPEN "<"
+                    Block
+                      Variable Declaration
+                        Local Variable Declaration
+                          Type: JLT_RWD_INT
+                          Variable Declarators
+                            Variable Declarator: tmp
+                              Expression
+                                Primary
+                                  9
+                      Expression Statement
+                        Expression
+                          Primary
+                            y
+                          Primary
+                            2
+                          OP[32]: OPID_ADD_ASN -> JLT_SYM_ADD_ASSIGNMENT "+="
+                      Variable Declaration
+                        Local Variable Declaration
+                          Type: JLT_RWD_INT
+                          Variable Declarators
+                            Variable Declarator: tmp2
+                      Expression Statement
+                        Expression
+                          Primary
+                            tmp
+                          Primary
+                            tmp
+                          Primary
+                            y
+                          Primary
+                            9
+                          OP[9]: OPID_MUL -> JLT_SYM_ASTERISK "*"
+                          OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                          OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+                      Return Statement
+                        Expression
+                          Primary
+                            tmp2
+                    Block
+                      Return Statement
+                        Expression
+                          Primary
+                            r3
+                While Statement
+                  Expression
+                    Primary
+                      x
+                    Primary
+                      y
+                    OP[17]: OPID_LESS -> JLT_SYM_ANGLE_BRACKET_OPEN "<"
+                  Block
+                    Expression Statement
+                      Expression
+                        Primary
+                          x
+                        OP[1]: OPID_POST_INC -> JLT_SYM_INCREMENT "++"
+                Return Statement
+                  Expression
+                    Primary
+                      0
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_VOID
+          Method Declaration
+            Method Header: loop_do_while
+            Method Body
+              Block
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: x
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: y
+                Do-While Statement
+                  Block
+                    If Statement
+                      Expression
+                        Primary
+                          4
+                        Primary
+                          9
+                        OP[22]: OPID_EQ -> JLT_SYM_RELATIONAL_EQUAL "=="
+                      Break Statement: (null)
+                    Expression Statement
+                      Expression
+                        Primary
+                          x
+                        OP[2]: OPID_POST_DEC -> JLT_SYM_DECREMENT "--"
+                    If Statement
+                      Expression
+                        Primary
+                          6
+                        Primary
+                          2
+                        OP[20]: OPID_GREAT_EQ -> JLT_SYM_GREATER_EQUAL ">="
+                      Block
+                        Continue Statement: (null)
+                  Expression
+                    Primary
+                      x
+                    Primary
+                      y
+                    OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_VOID
+          Method Declaration
+            Method Header: loop_for
+            Method Body
+              Block
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: x
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: y
+                For Statement
+                  For Initialization
+                    Local Variable Declaration
+                      Type: JLT_RWD_INT
+                      Variable Declarators
+                        Variable Declarator: a
+                          Expression
+                            Primary
+                              0
+                        Variable Declarator: b
+                  Expression
+                    Primary
+                      a
+                    Primary
+                      b
+                    OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                    Primary
+                      2
+                    Primary
+                      y
+                    OP[27]: OPID_LOGIC_AND -> JLT_SYM_LOGIC_AND "&&"
+                    OP[28]: OPID_LOGIC_OR -> JLT_SYM_LOGIC_OR "||"
+                  For Update
+                    Expression List
+                      Expression
+                        Primary
+                          a
+                        OP[1]: OPID_POST_INC -> JLT_SYM_INCREMENT "++"
+                      Expression
+                        Primary
+                          b
+                        OP[1]: OPID_POST_INC -> JLT_SYM_INCREMENT "++"
+                      Expression
+                        Primary
+                          y
+                        OP[1]: OPID_POST_INC -> JLT_SYM_INCREMENT "++"
+                  Block
+                    If Statement
+                      Expression
+                        Primary
+                          4
+                        Primary
+                          9
+                        OP[22]: OPID_EQ -> JLT_SYM_RELATIONAL_EQUAL "=="
+                      Break Statement: (null)
+                    Expression Statement
+                      Expression
+                        Primary
+                          x
+                        OP[2]: OPID_POST_DEC -> JLT_SYM_DECREMENT "--"
+                    If Statement
+                      Expression
+                        Primary
+                          6
+                        Primary
+                          2
+                        OP[20]: OPID_GREAT_EQ -> JLT_SYM_GREATER_EQUAL ">="
+                      Block
+                        Continue Statement: (null)
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_VOID
+          Method Declaration
+            Method Header: dec_inc
+            Method Body
+              Block
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: a
+                        Expression
+                          Primary
+                            0
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: b
+                        Expression
+                          Primary
+                            0
+                Expression Statement
+                  Expression
+                    Primary
+                      a
+                    Primary
+                      b
+                    OP[1]: OPID_POST_INC -> JLT_SYM_INCREMENT "++"
+                    Primary
+                      b
+                    OP[1]: OPID_POST_INC -> JLT_SYM_INCREMENT "++"
+                    OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                    OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_VOID
+          Method Declaration
+            Method Header: def_use
+            Method Body
+              Block
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: a
+                        Expression
+                          Primary
+                            0
+                Variable Declaration
+                  Local Variable Declaration
+                    Type: JLT_RWD_INT
+                    Variable Declarators
+                      Variable Declarator: b
+                        Expression
+                          Primary
+                            0
+                Expression Statement
+                  Expression
+                    Primary
+                      a
+                    Primary
+                      b
+                    OP[1]: OPID_POST_INC -> JLT_SYM_INCREMENT "++"
+                    OP[9]: OPID_MUL -> JLT_SYM_ASTERISK "*"
+                    Primary
+                      2
+                    OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+        Class Body Declaration: public static
+          Type: JLT_RWD_VOID
+          Method Declaration
+            Method Header: basic
+            Method Body
+              Block
+
+===== IMPORTS =====
+count: 4
+memory: 248 bytes
+load factor: 36.36%
+longest chain: 2
+    somepackage: (ON-DEMAND)
+    Scanner: FROM java.util
+    DecimalFormat: FROM java.text
+    InputMismatchException: FROM java.util
+
+===== GLOBAL NAMES =====
+count: 1
+memory: 128 bytes
+load factor: 9.09%
+longest chain: 1
+    MyPackageClass: Access: No Modifier extends C1 implements: C2, C3, 10 member(s)
+        Member Variable Initialization:
+>            Definition Pool: 0 definition(s), 40 byte(s)
+|            node[0] (entry point) <ANY> -> 1
+|                [0000012E225EFB40][0]: (li: 0x1{1}) IROP_GT (li: 0x2{2})
+|                [0000012E225EF4C0][0]: (li: 0x4{4}) IROP_MUL (li: 0x5{5})
+|                [0000012E225EF600][0]: (li: 0x3{3}) IROP_ADD (inst: 0000012E225EF4C0)
+|                [0000012E225EF5C0][0]: (li: 0x6{6}) IROP_SUB (li: 0x7{7})
+|                [0000012E225EF640][0]: (inst: 0000012E225EF600) IROP_TB (inst: 0000012E225EF5C0)
+|                [0000012E225EF280][0]: (inst: 0000012E225EFB40) IROP_TC (inst: 0000012E225EF640)
+|                [0000012E225EF300][0]: (def[0]: 0000000000000000) <- (inst: 0000012E225EF280) IROP_ASN (null)
+|            node[1] <ANY>
+|                [0000012E225EFB80][1]: (li: 0x0{0}) IROP_STORE (null)
+|                [0000012E225F0080][1]: (def[0]: 0000000000000000) <- (inst: 0000012E225EFB80) IROP_ASN (null)
+|                [0000012E225EFF80][1]: (def[0]: 0000000000000000) <- (null) IROP_INIT (null)
+>>>>> SUMMARY <<<<<
+node count: 2
+node arr size: 2
+edge count: 1
+edge arr size: 2
+instruction count: 10
+memory size: 864 bytes
+
+        Member:
+        calc: def method, Access: private, Return: JLT_RWD_INT
+>            Definition Pool: 5 definition(s), 728 byte(s)
+>                [0](0000012E225F1AE0): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [1](0000012E225F1A50): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [2](0000012E225F19C0): def var, Access: No Modifier, Type: JLT_RWD_SHORT
+>                [3](0000012E225F1DB0): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [4](0000012E225F22C0): def var, Access: No Modifier, Type: JLT_RWD_INT
+|            node[0] (entry point) <TEST> -> 1(FALSE) -> 2(TRUE)
+|                [0000012E225EF400][0]: (def[0]: 0000012E225F22C0) IROP_GT (def[0]: 0000012E225F1DB0)
+|                [0000012E225EF480][0]: (null) IROP_TEST (null)
+|            node[1] <TEST> -> 7(TRUE) -> 9(FALSE)
+|                [0000012E225EFEC0][1]: (li: 0x2{2}) IROP_GT (li: 0x1{1})
+|                [0000012E225EF780][1]: (null) IROP_TEST (null)
+|            node[2] <TEST> -> 3(TRUE) -> 4(FALSE)
+|                [0000012E225EF7C0][2]: (li: 0x4{4}) IROP_EQ (li: 0x9{9})
+|                [0000012E225EFBC0][2]: (null) IROP_TEST (null)
+|            node[3] <BREAK> -> 1(JMP) -> 4
+|                [0000012E225EFC80][3]: (null) IROP_JMP (null)
+|            node[4] <TEST> -> 5(TRUE) -> 6(FALSE)
+|                [0000012E225EF880][4]: (def[0]: 0000012E225F22C0) IROP_STORE (null)
+|                [0000012E225EF9C0][4]: (def[1]: 0000012E225F22C0) <- (li: 0x1{1}) IROP_SUB (def[0]: 0000012E225F22C0)
+|                [0000012E225EFB00][4]: (li: 0x6{6}) IROP_GE (li: 0x2{2})
+|                [0000012E225EF180][4]: (null) IROP_TEST (null)
+|            node[5] <CONTINUE> -> 0(JMP) -> 6
+|                [0000012E225EFF00][5]: (null) IROP_JMP (null)
+|            node[6] <ANY> -> 0(JMP)
+|                (no instructions)
+|            node[7] <RETURN> -> 8
+|                [0000012E225EFF40][7]: (def[1]: 0000012E225F22C0) IROP_ADD (def[0]: 0000012E225F1DB0)
+|                [0000012E225F57C0][7]: (def[0]: 0000012E225F19C0) IROP_SUB (li: 0x6{6})
+|                [0000012E225F58C0][7]: (inst: 0000012E225F57C0) IROP_ADD (def[0]: 0000012E225F1DB0)
+|                [0000012E225F5B00][7]: (def[1]: 0000012E225E0EF0) <- (inst: 0000012E225F58C0) IROP_ASN (null)
+|                [0000012E225F5B40][7]: (li: 0x3{3}) IROP_STORE (null)
+|                [0000012E225F52C0][7]: (inst: 0000012E225F5B40) IROP_RET (null)
+|            node[8] <TEST> -> 13(FALSE) -> 14(TRUE)
+|                [0000012E225F5AC0][8]: (def[1]: 0000012E225F22C0) IROP_LT (def[1]: 0000012E225F1DB0)
+|                [0000012E225F5E40][8]: (null) IROP_TEST (null)
+|            node[9] <TEST> -> 10(TRUE) -> 12(FALSE)
+|                [0000012E225F5D00][9]: (def[0]: 0000012E225F19C0) IROP_LT (def[1]: 0000012E225F22C0)
+|                [0000012E225F5780][9]: (null) IROP_TEST (null)
+|            node[10] <RETURN> -> 11
+|                [0000012E225F5080][10]: (li: 0x9{9}) IROP_STORE (null)
+|                [0000012E225F5400][10]: (def[0]: 0000012E225F1A50) <- (inst: 0000012E225F5080) IROP_ASN (null)
+|                [0000012E225F5CC0][10]: (def[1]: 0000012E225F1DB0) <- (def[0]: 0000012E225F1DB0) IROP_ADD (li: 0x2{2})
+|                [0000012E225F5380][10]: (def[0]: 0000012E225F1AE0) <- (null) IROP_INIT (null)
+|                [0000012E225F5040][10]: (def[1]: 0000012E225F1DB0) IROP_MUL (li: 0x9{9})
+|                [0000012E225F5980][10]: (def[0]: 0000012E225F1A50) IROP_SUB (inst: 0000012E225F5040)
+|                [0000012E225F5680][10]: (def[1]: 0000012E225F1A50) <- (inst: 0000012E225F5980) IROP_ASN (null)
+|                [0000012E225F4F80][10]: (def[0]: 0000012E225F1AE0) IROP_STORE (null)
+|                [0000012E225F5840][10]: (inst: 0000012E225F4F80) IROP_RET (null)
+|            node[11] <ANY> -> 8
+|                (no instructions)
+|            node[12] <RETURN> -> 11
+|                [0000012E225F5900][12]: (def[1]: 0000012E225E0EF0) IROP_STORE (null)
+|                [0000012E225F5BC0][12]: (inst: 0000012E225F5900) IROP_RET (null)
+|            node[13] <RETURN>
+|                [0000012E225F5480][13]: (li: 0x0{0}) IROP_STORE (null)
+|                [0000012E225F5880][13]: (inst: 0000012E225F5480) IROP_RET (null)
+|            node[14] <ANY> -> 8(JMP)
+|                [0000012E225F5440][14]: (def[1]: 0000012E225F22C0) IROP_STORE (null)
+|                [0000012E225F5B80][14]: (def[2]: 0000012E225F22C0) <- (li: 0x1{1}) IROP_ADD (def[1]: 0000012E225F22C0)
+>>>>> SUMMARY <<<<<
+node count: 15
+node arr size: 16
+edge count: 22
+edge arr size: 32
+instruction count: 37
+memory size: 4720 bytes
+
+        def_use: def method, Access: No Modifier, Return: JLT_RWD_VOID
+>            Definition Pool: 2 definition(s), 296 byte(s)
+>                [0](0000012E225F1FF0): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [1](0000012E225F2470): def var, Access: No Modifier, Type: JLT_RWD_INT
+|            node[0] (entry point) <ANY>
+|                [0000012E225FF4B0][0]: (li: 0x0{0}) IROP_STORE (null)
+|                [0000012E225FFBB0][0]: (def[0]: 0000012E225F2470) <- (inst: 0000012E225FF4B0) IROP_ASN (null)
+|                [0000012E225FF0B0][0]: (li: 0x0{0}) IROP_STORE (null)
+|                [0000012E225FF730][0]: (def[0]: 0000012E225F1FF0) <- (inst: 0000012E225FF0B0) IROP_ASN (null)
+|                [0000012E225FF1F0][0]: (def[0]: 0000012E225F1FF0) IROP_STORE (null)
+|                [0000012E225FEDF0][0]: (def[1]: 0000012E225F1FF0) <- (li: 0x1{1}) IROP_ADD (def[0]: 0000012E225F1FF0)
+|                [0000012E225FEDB0][0]: (def[0]: 0000012E225F2470) IROP_MUL (inst: 0000012E225FF1F0)
+|                [0000012E225FF630][0]: (inst: 0000012E225FEDB0) IROP_SUB (li: 0x2{2})
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 8
+memory size: 616 bytes
+
+        dec_inc: def method, Access: No Modifier, Return: JLT_RWD_VOID
+>            Definition Pool: 2 definition(s), 296 byte(s)
+>                [0](0000012E225F2110): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [1](0000012E225F1F60): def var, Access: No Modifier, Type: JLT_RWD_INT
+|            node[0] (entry point) <ANY>
+|                [0000012E225FF4F0][0]: (li: 0x0{0}) IROP_STORE (null)
+|                [0000012E225FF530][0]: (def[0]: 0000012E225F1F60) <- (inst: 0000012E225FF4F0) IROP_ASN (null)
+|                [0000012E225FFA30][0]: (li: 0x0{0}) IROP_STORE (null)
+|                [0000012E225FFC30][0]: (def[0]: 0000012E225F2110) <- (inst: 0000012E225FFA30) IROP_ASN (null)
+|                [0000012E225FF670][0]: (def[0]: 0000012E225F2110) IROP_STORE (null)
+|                [0000012E225FED30][0]: (def[1]: 0000012E225F2110) <- (li: 0x1{1}) IROP_ADD (def[0]: 0000012E225F2110)
+|                [0000012E225FFA70][0]: (def[1]: 0000012E225F2110) IROP_STORE (null)
+|                [0000012E225FED70][0]: (def[2]: 0000012E225F2110) <- (li: 0x1{1}) IROP_ADD (def[1]: 0000012E225F2110)
+|                [0000012E225FF3F0][0]: (inst: 0000012E225FF670) IROP_ADD (inst: 0000012E225FFA70)
+|                [0000012E225FFB30][0]: (def[1]: 0000012E225F1F60) <- (inst: 0000012E225FF3F0) IROP_ASN (null)
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 10
+memory size: 728 bytes
+
+        basic: def method, Access: public static, Return: JLT_RWD_VOID
+>            Definition Pool: 0 definition(s), 40 byte(s)
+|            node[0] (entry point) <ANY>
+|                (no instructions)
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 0
+memory size: 168 bytes
+
+        r4: def member var, Access: No Modifier, Type: JLT_RWD_SHORT
+        r2: def member var, Access: No Modifier, Type: JLT_RWD_INT
+        logic: def method, Access: No Modifier, Return: JLT_RWD_VOID
+>            Definition Pool: 0 definition(s), 40 byte(s)
+|            node[0] (entry point) <TEST> -> 2(FALSE) -> 1(TRUE)
+|                [0000012E225EF340][0]: (li: 0x1{1}) IROP_STORE (null)
+|                [0000012E225EF740][0]: (null) IROP_TEST (null)
+|            node[1] <TEST> -> 4(FALSE) -> 3(TRUE)
+|                [0000012E225F00C0][1]: (inst: 0000012E225EF340) IROP_PHI (inst: 0000012E225EF700)
+|                [0000012E225EF380][1]: (null) IROP_TEST (null)
+|            node[2] <ANY> -> 1
+|                [0000012E225EF700][2]: (li: 0x2{2}) IROP_STORE (null)
+|            node[3] <ANY>
+|                [0000012E225EF6C0][3]: (inst: 0000012E225F00C0) IROP_PHI (inst: 0000012E225EFE40)
+|            node[4] <ANY> -> 3
+|                [0000012E225EFE40][4]: (li: 0x3{3}) IROP_ADD (li: 0x4{4})
+>>>>> SUMMARY <<<<<
+node count: 5
+node arr size: 8
+edge count: 6
+edge arr size: 8
+instruction count: 7
+memory size: 1248 bytes
+
+        r3: def member var, Access: No Modifier, Type: JLT_RWD_INT
+        loop_do_while: def method, Access: No Modifier, Return: JLT_RWD_VOID
+>            Definition Pool: 2 definition(s), 296 byte(s)
+>                [0](0000012E225F1E40): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [1](0000012E225F1B70): def var, Access: No Modifier, Type: JLT_RWD_INT
+|            node[0] (entry point) <ANY> -> 1
+|                [0000012E225F5C80][0]: (def[0]: 0000012E225F1B70) <- (null) IROP_INIT (null)
+|                [0000012E225F54C0][0]: (def[0]: 0000012E225F1E40) <- (null) IROP_INIT (null)
+|            node[1] <ANY> -> 4
+|                (no instructions)
+|            node[2] <TEST> -> 1(TRUE) -> 3(FALSE)
+|                [0000012E225F5100][2]: (def[1]: 0000012E225F1B70) IROP_GT (def[0]: 0000012E225F1E40)
+|                [0000012E225F5540][2]: (null) IROP_TEST (null)
+|            node[3] <ANY>
+|                (no instructions)
+|            node[4] <TEST> -> 5(TRUE) -> 6(FALSE)
+|                [0000012E225F4FC0][4]: (li: 0x4{4}) IROP_EQ (li: 0x9{9})
+|                [0000012E225F5000][4]: (null) IROP_TEST (null)
+|            node[5] <BREAK> -> 3(JMP) -> 6
+|                [0000012E225F5940][5]: (null) IROP_JMP (null)
+|            node[6] <TEST> -> 7(TRUE) -> 8(FALSE)
+|                [0000012E225F5EC0][6]: (def[0]: 0000012E225F1B70) IROP_STORE (null)
+|                [0000012E225F50C0][6]: (def[1]: 0000012E225F1B70) <- (li: 0x1{1}) IROP_SUB (def[0]: 0000012E225F1B70)
+|                [0000012E225F5D40][6]: (li: 0x6{6}) IROP_GE (li: 0x2{2})
+|                [0000012E225F5240][6]: (null) IROP_TEST (null)
+|            node[7] <CONTINUE> -> 2(JMP) -> 8
+|                [0000012E225F5C40][7]: (null) IROP_JMP (null)
+|            node[8] <ANY> -> 2
+|                (no instructions)
+>>>>> SUMMARY <<<<<
+node count: 9
+node arr size: 16
+edge count: 13
+edge arr size: 16
+instruction count: 12
+memory size: 2272 bytes
+
+        loop_for: def method, Access: No Modifier, Return: JLT_RWD_VOID
+>            Definition Pool: 4 definition(s), 568 byte(s)
+>                [0](0000012E225F2620): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [1](0000012E225F27D0): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [2](0000012E225F1ED0): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                [3](0000012E225F1C00): def var, Access: No Modifier, Type: JLT_RWD_INT
+|            node[0] (entry point) <ANY> -> 1
+|                [0000012E225F59C0][0]: (def[0]: 0000012E225F1C00) <- (null) IROP_INIT (null)
+|                [0000012E225F5C00][0]: (def[0]: 0000012E225F1ED0) <- (null) IROP_INIT (null)
+|                [0000012E225F5D80][0]: (li: 0x0{0}) IROP_STORE (null)
+|                [0000012E225F5200][0]: (def[0]: 0000012E225F27D0) <- (inst: 0000012E225F5D80) IROP_ASN (null)
+|                [0000012E225F56C0][0]: (def[0]: 0000012E225F2620) <- (null) IROP_INIT (null)
+|            node[1] <TEST> -> 5(FALSE) -> 4(TRUE)
+|                [0000012E225F5A00][1]: (def[0]: 0000012E225F27D0) IROP_GT (def[0]: 0000012E225F2620)
+|                [0000012E225F5580][1]: (null) IROP_TEST (null)
+|            node[2] <ANY> -> 4
+|                [0000012E225F55C0][2]: (inst: 0000012E225F5DC0) IROP_PHI (inst: 0000012E225F5E00)
+|            node[3] <ANY> -> 2
+|                [0000012E225F5E00][3]: (def[0]: 0000012E225F1ED0) IROP_STORE (null)
+|            node[4] <TEST> -> 7(FALSE) -> 8(TRUE)
+|                [0000012E225F5A80][4]: (inst: 0000012E225F5A00) IROP_PHI (inst: 0000012E225F55C0)
+|                [0000012E225F5140][4]: (null) IROP_TEST (null)
+|            node[5] <ANY> -> 3(TRUE) -> 2(FALSE)
+|                [0000012E225F5DC0][5]: (li: 0x2{2}) IROP_STORE (null)
+|                [0000012E225F5E80][5]: (null) IROP_TEST (null)
+|            node[6] <ANY> -> 1(JMP)
+|                [0000012E225F5600][6]: (def[0]: 0000012E225F27D0) IROP_STORE (null)
+|                [0000012E225F5640][6]: (def[1]: 0000012E225F27D0) <- (li: 0x1{1}) IROP_ADD (def[0]: 0000012E225F27D0)
+|                [0000012E225F5180][6]: (def[0]: 0000012E225F2620) IROP_STORE (null)
+|                [0000012E225F5280][6]: (def[1]: 0000012E225F2620) <- (li: 0x1{1}) IROP_ADD (def[0]: 0000012E225F2620)
+|                [0000012E225F51C0][6]: (def[0]: 0000012E225F1ED0) IROP_STORE (null)
+|                [0000012E225F5340][6]: (def[1]: 0000012E225F1ED0) <- (li: 0x1{1}) IROP_ADD (def[0]: 0000012E225F1ED0)
+|            node[7] <ANY>
+|                (no instructions)
+|            node[8] <TEST> -> 9(TRUE) -> 10(FALSE)
+|                [0000012E225F5740][8]: (li: 0x4{4}) IROP_EQ (li: 0x9{9})
+|                [0000012E225EF500][8]: (null) IROP_TEST (null)
+|            node[9] <BREAK> -> 7(JMP) -> 10
+|                [0000012E225EF680][9]: (null) IROP_JMP (null)
+|            node[10] <TEST> -> 11(TRUE) -> 12(FALSE)
+|                [0000012E225EF800][10]: (def[0]: 0000012E225F1C00) IROP_STORE (null)
+|                [0000012E225EFAC0][10]: (def[1]: 0000012E225F1C00) <- (li: 0x1{1}) IROP_SUB (def[0]: 0000012E225F1C00)
+|                [0000012E225EF940][10]: (li: 0x6{6}) IROP_GE (li: 0x2{2})
+|                [0000012E225EFC00][10]: (null) IROP_TEST (null)
+|            node[11] <CONTINUE> -> 6(JMP) -> 12
+|                [0000012E225FEC70][11]: (null) IROP_JMP (null)
+|            node[12] <ANY> -> 6
+|                (no instructions)
+>>>>> SUMMARY <<<<<
+node count: 13
+node arr size: 16
+edge count: 19
+edge arr size: 32
+instruction count: 27
+memory size: 3832 bytes
+
+
+===== LITERALS =====
+count: 9
+memory: 536 bytes
+load factor: 40.91%
+longest chain: 1
+    1: number, 0x1
+    9: number, 0x9
+    7: number, 0x7
+    5: number, 0x5
+    0: number, 0x0
+    3: number, 0x3
+    2: number, 0x2
+    6: number, 0x6
+    4: number, 0x4
+
+===== LOOKUP STACK =====
+(lookup stack is empty)
+Press any key to continue . . .

--- a/string-list.c
+++ b/string-list.c
@@ -16,6 +16,7 @@ void init_string_list(string_list* sl)
 {
     sl->first = NULL;
     sl->last = NULL;
+    sl->count = 0;
 }
 
 // delete entire list
@@ -31,9 +32,6 @@ void release_string_list(string_list* sl)
 
         e = sl->first;
     }
-
-    sl->first = NULL;
-    sl->last = NULL;
 }
 
 /**
@@ -62,6 +60,7 @@ void string_list_append(string_list* sl, void* str_data)
     }
 
     sl->last = e;
+    sl->count++;
 }
 
 // pop front
@@ -78,6 +77,7 @@ char* string_list_pop_front(string_list* sl)
     sl->first = e->next;
     free(e);
     sl->first->prev = NULL;
+    sl->count--;
 
     return s;
 }
@@ -105,4 +105,19 @@ char* string_list_concat(string_list* sl, const char* dlim)
     }
 
     return s;
+}
+
+// flatten into simple string array
+char** string_list_to_string_array(string_list* sl)
+{
+    string_list_item* e = sl->first;
+    char** arr = (char**)malloc_assert(sizeof(char*) * sl->count);
+
+    for (size_t i = 0; e != NULL; i++)
+    {
+        arr[i] = strmcpy_assert(e->s);
+        e = e->next;
+    }
+
+    return arr;
 }

--- a/string-list.h
+++ b/string-list.h
@@ -19,6 +19,7 @@ typedef struct _string_list
 {
     string_list_item* first;
     string_list_item* last;
+    size_t count;
 } string_list;
 
 void init_string_list(string_list* sl);
@@ -26,5 +27,6 @@ void release_string_list(string_list* sl);
 void string_list_append(string_list* sl, void* str_data);
 char* string_list_pop_front(string_list* sl);
 char* string_list_concat(string_list* sl, const char* dlim);
+char** string_list_to_string_array(string_list* sl);
 
 #endif

--- a/types.c
+++ b/types.c
@@ -32,7 +32,11 @@ char* strmcpy_assert(const char* source)
         return NULL;
     }
 
-    char* s = (char*)malloc_assert(sizeof(char) * (strlen(source) + 1));
+    size_t len = strlen(source);
+    char* s = (char*)malloc_assert(sizeof(char) * (len + 1));
+
     strcpy(s, source);
+    s[len] = '\0';
+
     return s;
 }


### PR DESCRIPTION
Introduced new IR architecture which will encapsulate each individual top-level into a separate object.
* implemented `global_import` to describe imported names
* implemented `global_top_level` to describe top-level instance
* redesigned lookup hierarchy: now a compilation unit has an import scope and a global scope for lookup; and the global scope has all names associate with a top-level definition `global_top_level`, which has a table to lookup all members within
* designed `definition` query type: it deprecates the use of `JNT_*` as type, instead it uses a new independent descriptor `definition_type`
* refactored IR entry point: `ctx_*`  interfaces are deprecated and now moved to `walk_*` family
* reduced `definition` size: now that import and top-level definitions are described separately, `definition` does not have to manage them anymore
* new debug print: formatted debug output is redesigned to cope with the new IR architecture