### PR TITLE
[IR] Function Overloading

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -334,7 +334,9 @@ tree_node* ast_node_constructor_declaration()
     tree_node* node = ast_node_new(JNT_CTOR_DECL);
 
     node->data = ast_node_data_new();
-    node->data->id.complex = ast_node_data_new_token();
+    node->data->declarator.id.simple = JLT_MAX; // unused
+    node->data->declarator.id.complex = ast_node_data_new_token();
+    node->data->declarator.dimension = 0; // unused
 
     return node;
 }
@@ -365,6 +367,7 @@ tree_node* ast_node_method_header()
     tree_node* node = ast_node_new(JNT_METHOD_HEADER);
 
     node->data = ast_node_data_new();
+    node->data->declarator.id.simple = JLT_MAX; // unused
     node->data->declarator.id.complex = ast_node_data_new_token();
     node->data->declarator.dimension = 0;
 
@@ -417,6 +420,7 @@ tree_node* ast_node_formal_parameter()
     tree_node* node = ast_node_new(JNT_FORMAL_PARAM);
 
     node->data = ast_node_data_new();
+    node->data->declarator.id.simple = JLT_MAX; // unused
     node->data->declarator.id.complex = ast_node_data_new_token();
     node->data->declarator.dimension = 0;
 
@@ -481,6 +485,7 @@ tree_node* ast_node_variable_declarator()
     tree_node* node = ast_node_new(JNT_VAR_DECL);
 
     node->data = ast_node_data_new();
+    node->data->declarator.id.simple = JLT_MAX; // unused
     node->data->declarator.id.complex = ast_node_data_new_token();
     node->data->declarator.dimension = 0;
 

--- a/debug.c
+++ b/debug.c
@@ -1006,7 +1006,7 @@ static void debug_print_ast_node(java_parser* parser, tree_node* node)
             break;
         case JNT_CTOR_DECL:
             printf("Constructor Declaration: ");
-            debug_print_token_content(node->data->id.complex);
+            debug_print_token_content(node->data->declarator.id.complex);
             break;
         case JNT_TYPE:
             printf("Type: ");
@@ -1641,6 +1641,10 @@ static void debug_print_definition_pool(definition_pool* pool, size_t depth);
 
 static void debug_print_definition(definition* v, size_t depth)
 {
+    static const char* method_regular = "method";
+    static const char* method_ctor = "constructor";
+    java_lexeme_type lex_type;
+
     switch (v->type)
     {
         case DEFINITION_VARIABLE:
@@ -1669,10 +1673,33 @@ static void debug_print_definition(definition* v, size_t depth)
             printf("\n");
             break;
         case DEFINITION_METHOD:
-            printf("def method, ");
+            printf("def %s, ", v->method.is_constructor ? method_ctor : method_regular);
 
             printf("Access: ");
             debug_print_modifier_bit_flag(v->method.modifier);
+
+            printf(", Parameter Count: %zd(", v->method.parameter_count);
+            for (size_t i = 0; i < v->method.parameter_count; i++)
+            {
+                if (i > 0) { printf(" "); }
+
+                lex_type = v->method.parameters[i]->variable.type.primitive;
+
+                for (size_t j = v->method.parameters[i]->variable.type.dim; j > 0; j--)
+                {
+                    printf("[");
+                }
+
+                if (lex_type == JLT_MAX)
+                {
+                    printf("L%s;", v->method.parameters[i]->variable.type.reference);
+                }
+                else
+                {
+                    printf("%c", primitive_type_to_jil_type(lex_type));
+                }
+            }
+            printf(")");
 
             printf(", Return: ");
             if (v->method.return_type.primitive != JLT_MAX)

--- a/ir-scope.c
+++ b/ir-scope.c
@@ -186,6 +186,8 @@ definition* new_definition(definition_type type)
 
     v->type = type;
     v->def_count = 0;
+    v->sid = 0;
+    v->root_code_walk = NULL;
 
     switch (type)
     {
@@ -196,6 +198,9 @@ definition* new_definition(definition_type type)
             break;
         case DEFINITION_METHOD:
             v->method.modifier = JLT_UNDEFINED;
+            v->method.is_constructor = false;
+            v->method.parameter_count = 0;
+            v->method.parameters = NULL;
             __init_type_name(&v->method.return_type);
             init_definition_pool(&v->method.local_variables);
             // no code CFG initialization here as parser will do it
@@ -233,6 +238,7 @@ void definition_delete(definition* v)
             break;
         case DEFINITION_METHOD:
             free(v->method.return_type.reference);
+            free(v->method.parameters);
             release_definition_pool(&v->method.local_variables);
             release_cfg(&v->method.code);
             break;

--- a/ir-type.c
+++ b/ir-type.c
@@ -3,5 +3,21 @@
 */
 
 #include "ir.h"
+#include "jil.h"
 
-
+char primitive_type_to_jil_type(java_lexeme_type p)
+{
+    switch (p)
+    {
+        case JLT_RWD_BOOLEAN: return JIL_TYPE_BOOL;
+        case JLT_RWD_DOUBLE: return JIL_TYPE_DOUBLE;
+        case JLT_RWD_BYTE: return JIL_TYPE_BYTE;
+        case JLT_RWD_INT: return JIL_TYPE_INT;
+        case JLT_RWD_SHORT: return JIL_TYPE_SHORT;
+        case JLT_RWD_VOID: return JIL_TYPE_VOID;
+        case JLT_RWD_CHAR: return JIL_TYPE_CHAR;
+        case JLT_RWD_LONG: return JIL_TYPE_LONG;
+        case JLT_RWD_FLOAT: return JIL_TYPE_FLOAT;
+        default: return 0x00;
+    }
+}

--- a/ir.c
+++ b/ir.c
@@ -317,7 +317,7 @@ global_top_level* new_global_top_level(top_level_type type)
     top->implement = NULL;
     top->num_implement = 0;
     top->code_member_init = NULL;
-    top->node_top_level = NULL;
+    top->node_first_body_decl = NULL;
     top->num_member_variable = 0;
 
     init_definition_pool(&top->member_init_variables);

--- a/ir.h
+++ b/ir.h
@@ -320,11 +320,14 @@ typedef enum
 */
 typedef struct _definition
 {
+    // definition type
     definition_type type;
+    // used by dataflow analysis
     size_t def_count;
-
     // serialization id, used during IR emit process
     size_t sid;
+    // internal-only: the code walk root
+    tree_node* root_code_walk;
 
     union
     {
@@ -342,6 +345,12 @@ typedef struct _definition
         {
             // modifier
             lbit_flag modifier;
+            // if method is a constructor
+            bool is_constructor;
+            // parameter count
+            size_t parameter_count;
+            // ordered parameter definition
+            struct _definition** parameters;
             // return type
             type_name return_type;
             // code
@@ -496,10 +505,6 @@ typedef enum
  * top level mey be referenced by others so
  * we need to export them
  *
- * node_top_level: only used as a quick access after
- *                 def_global, will not be used
- *                 during serialization process
- *
 */
 typedef struct
 {
@@ -524,8 +529,8 @@ typedef struct
 
     /* following fields are internal-use only */
 
-    // JNT_TOP_LEVEL node reference
-    tree_node* node_top_level;
+    // internal-only: first JNT_CLASS_BODY_DECL node reference
+    tree_node* node_first_body_decl;
     // member definition order tracker
     size_t num_member_variable;
 } global_top_level;
@@ -657,7 +662,7 @@ definition* type2def(
 );
 definition* def_var(java_ir* ir, tree_node* node, definition** type, def_use_control duc, bool is_member);
 void def_vars(java_ir* ir, tree_node* node, lbit_flag modifier, bool is_member);
-void def_params(java_ir* ir, tree_node* node);
+void def_params(java_ir* ir, tree_node* node, definition** ordered_list);
 void def_global(java_ir* ir, tree_node* compilation_unit);
 
 definition* new_definition(definition_type type);
@@ -733,6 +738,8 @@ instruction* instruction_locate_enclosure_start(instruction* inst);
 
 void walk_class(java_ir* ir, global_top_level* class);
 void walk_interface(java_ir* ir, global_top_level* interface);
+
+char primitive_type_to_jil_type(java_lexeme_type p);
 
 void init_ir(java_ir* ir, java_expression* expression, java_error_stack* error);
 void release_ir(java_ir* ir);

--- a/main.c
+++ b/main.c
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
 
         if (compile(&compiler, &arch, test_paths[i]))
         {
-            // debug_ast(&compiler.context);
+            debug_ast(&compiler.context);
             debug_print_global_import(&compiler.ir);
             debug_ir_global_names(&compiler.ir);
             debug_ir_lookup(&compiler.ir);

--- a/output/2024-03-19.txt
+++ b/output/2024-03-19.txt
@@ -1,0 +1,409 @@
+===== COMPILER RUNTIME REPORT =====
+Language version: 1
+Reserved word:
+    count: 50
+    memory: 4824 bytes
+    load factor: 14.16%
+    longest chain: 1
+Expression static data size: 1072 bytes
+Error static data size: 574 bytes
+===== END OF REPORT =====
+
+File 1: ./test/il.txt
+all dominator sets:
+0: 0
+1: 0 1
+2: 2 0
+3: 0 3
+4: 0 3 4
+5: 0 3 5
+6: 0 3 6
+all DF sets:
+0:
+1: 2
+2:
+3: 2
+4: 5
+5: 2
+6: 5
+all dominator sets:
+0: 0
+all DF sets:
+0:
+all dominator sets:
+0: 0
+all DF sets:
+0:
+===== ABSTRACT SYNTAX TREE =====
+Compilation Unit
+  Package Declaration
+    Name
+      Unit: mypack
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: text
+      Unit: DecimalFormat
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: util
+      Unit: InputMismatchException
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: util
+      Unit: Scanner
+  Import Declaration (On-demand: true)
+    Name
+      Unit: somepackage
+  Top Level: No Modifier
+    Class Declaration: MyPackageClass
+      Class Extends
+        Class Type
+          Unit: C1
+      Class Implements
+        Interface Type List
+          Interface Type
+            Unit: C2
+          Interface Type
+            Unit: C3
+      Class Body
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_INT
+          Variable Declarators
+            Variable Declarator: r2
+              Expression
+                Primary
+                  1
+                Primary
+                  2
+                OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                Primary
+                  3
+                Primary
+                  4
+                Primary
+                  5
+                OP[9]: OPID_MUL -> JLT_SYM_ASTERISK "*"
+                OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                Primary
+                  6
+                Primary
+                  7
+                OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                OP[30]: OPID_TERNARY_2 -> JLT_SYM_COLON ":"
+                OP[29]: OPID_TERNARY_1 -> JLT_SYM_QUESTION "?"
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_INT
+          Variable Declarators
+            Variable Declarator: r3
+              Expression
+                Primary
+                  0
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_SHORT
+          Variable Declarators
+            Variable Declarator: r4
+        Class Body Declaration: No Modifier
+          Type: (Complex Type Shown In Sub-Tree)
+            Class Type
+              Unit: String
+          Variable Declarators
+            Variable Declarator: s
+              Expression
+                Primary
+                  "Hello, World!"
+        Class Body Declaration: No Modifier
+          Constructor Declaration: MyPackageClass
+            Constructor Body
+        Class Body Declaration: No Modifier
+          Constructor Declaration: MyPackageClass
+            Formal Parameter List
+              Formal Parameter: r
+                Type: JLT_RWD_INT
+            Constructor Body
+              Expression Statement
+                Expression
+                  Primary
+                    r2
+                  Primary
+                    r
+                  OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+        Class Body Declaration: private
+          Type: JLT_RWD_INT
+          Method Declaration
+            Method Header: calc
+              Formal Parameter List
+                Formal Parameter: x
+                  Type: JLT_RWD_INT
+                Formal Parameter: y
+                  Type: JLT_RWD_INT
+                Formal Parameter: sr1
+                  Type: (Complex Type Shown In Sub-Tree)
+                    Class Type
+                      Unit: String
+                      Unit: Impl
+                Formal Parameter: r2
+                  Type: JLT_RWD_SHORT
+            Method Body
+              Block
+                If Statement
+                  Expression
+                    Primary
+                      2
+                    Primary
+                      1
+                    OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                  Block
+                    Expression Statement
+                      Expression
+                        Primary
+                          x
+                        Primary
+                          y
+                        OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                    Expression Statement
+                      Expression
+                        Primary
+                          r3
+                        Primary
+                          r2
+                        Primary
+                          6
+                        OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                        Primary
+                          y
+                        OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                        OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+                    Return Statement
+                      Expression
+                        Primary
+                          3
+                  If Statement
+                    Expression
+                      Primary
+                        r2
+                      Primary
+                        x
+                      OP[17]: OPID_LESS -> JLT_SYM_ANGLE_BRACKET_OPEN "<"
+                    Block
+                      Variable Declaration
+                        Local Variable Declaration
+                          Type: JLT_RWD_INT
+                          Variable Declarators
+                            Variable Declarator: tmp
+                              Expression
+                                Primary
+                                  9
+                      Expression Statement
+                        Expression
+                          Primary
+                            y
+                          Primary
+                            2
+                          OP[32]: OPID_ADD_ASN -> JLT_SYM_ADD_ASSIGNMENT "+="
+                      Variable Declaration
+                        Local Variable Declaration
+                          Type: JLT_RWD_INT
+                          Variable Declarators
+                            Variable Declarator: tmp2
+                      Expression Statement
+                        Expression
+                          Primary
+                            tmp
+                          Primary
+                            tmp
+                          Primary
+                            y
+                          Primary
+                            9
+                          OP[9]: OPID_MUL -> JLT_SYM_ASTERISK "*"
+                          OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                          OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+                      Return Statement
+                        Expression
+                          Primary
+                            tmp2
+                    Block
+                      Return Statement
+                        Expression
+                          Primary
+                            r3
+                Return Statement
+                  Expression
+                    Primary
+                      0
+  Top Level: No Modifier
+    Class Declaration: SomeOtherClass
+      Class Body
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_INT
+          Variable Declarators
+            Variable Declarator: a
+              Expression
+                Primary
+                  1
+
+===== IMPORTS =====
+count: 4
+memory: 248 bytes
+load factor: 36.36%
+longest chain: 2
+    somepackage: (ON-DEMAND)
+    Scanner: FROM java.util
+    DecimalFormat: FROM java.text
+    InputMismatchException: FROM java.util
+
+===== GLOBAL NAMES =====
+count: 2
+memory: 168 bytes
+load factor: 18.18%
+longest chain: 1
+    MyPackageClass: Access: No Modifier extends C1 implements: C2, C3
+*       Member Variable Initialization:
+>            Definition Pool: 0 definition(s), 40 byte(s)
+|            node[0] (entry point) <ANY> -> 1
+|                [00000200D5D5C8E0][0]: (li unknown: 0x1a) IROP_STORE (null)
+|                [00000200D5D5C960][0]: (def[0]: 00000200D5D5A960) <- (inst: 00000200D5D5C8E0) IROP_ASN (null)
+|            node[1] <ANY> -> 2
+|                [00000200D5D5D3E0][1]: (li: 0x1{1}) IROP_GT (li: 0x2{2})
+|                [00000200D5D5CC20][1]: (li: 0x4{4}) IROP_MUL (li: 0x5{5})
+|                [00000200D5D5D060][1]: (li: 0x3{3}) IROP_ADD (inst: 00000200D5D5CC20)
+|                [00000200D5D5CF20][1]: (li: 0x6{6}) IROP_SUB (li: 0x7{7})
+|                [00000200D5D5CA20][1]: (inst: 00000200D5D5D060) IROP_TB (inst: 00000200D5D5CF20)
+|                [00000200D5D5CAE0][1]: (inst: 00000200D5D5D3E0) IROP_TC (inst: 00000200D5D5CA20)
+|                [00000200D5D5CEA0][1]: (def[0]: 00000200D5D50E90) <- (inst: 00000200D5D5CAE0) IROP_ASN (null)
+|            node[2] <ANY>
+|                [00000200D5D5CE60][2]: (li: 0x0{0}) IROP_STORE (null)
+|                [00000200D5D5CBE0][2]: (def[0]: 00000200D5D5A800) <- (inst: 00000200D5D5CE60) IROP_ASN (null)
+|                [00000200D5D5CF60][2]: (def[0]: 00000200D5D5A8B0) <- (null) IROP_INIT (null)
+>>>>> SUMMARY <<<<<
+node count: 3
+node arr size: 4
+edge count: 2
+edge arr size: 2
+instruction count: 12
+memory size: 1128 bytes
+
+*       Member: 7 member(s)
+            calcIILString.Impl;S: def method, Access: private, Parameter Count: 4(I I LString.Impl; S), Return: JLT_RWD_INT
+>                Definition Pool: 6 definition(s), 1048 byte(s)
+>                    [0](00000200D5D5E3E0): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [1](00000200D5D5D680): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [2](00000200D5D5B6F0): def var, Access: No Modifier, Type: JLT_RWD_SHORT
+>                    [3](00000200D5D5B590): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [4](00000200D5D5ACD0): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [5](00000200D5D5B640): def var, Access: No Modifier, Type: String.Impl
+|                node[0] (entry point) <TEST> -> 1(TRUE) -> 3(FALSE)
+|                    [00000200D5D5D4A0][0]: (li: 0x2{2}) IROP_GT (li: 0x1{1})
+|                    [00000200D5D5CB60][0]: (null) IROP_TEST (null)
+|                node[1] <RETURN> -> 2
+|                    [00000200D5D5CFE0][1]: (def[0]: 00000200D5D5ACD0) IROP_ADD (def[0]: 00000200D5D5B590)
+|                    [00000200D5D5C920][1]: (def[0]: 00000200D5D5B6F0) IROP_SUB (li: 0x6{6})
+|                    [00000200D5D5CD20][1]: (inst: 00000200D5D5C920) IROP_ADD (def[0]: 00000200D5D5B590)
+|                    [00000200D5D5D0A0][1]: (def[1]: 00000200D5D5A800) <- (inst: 00000200D5D5CD20) IROP_ASN (null)
+|                    [00000200D5D5C8A0][1]: (li: 0x3{3}) IROP_STORE (null)
+|                    [00000200D5D5CCA0][1]: (inst: 00000200D5D5C8A0) IROP_RET (null)
+|                node[2] <RETURN>
+|                    [00000200D5D5D360][2]: (li: 0x0{0}) IROP_STORE (null)
+|                    [00000200D5D5CD60][2]: (inst: 00000200D5D5D360) IROP_RET (null)
+|                node[3] <TEST> -> 4(TRUE) -> 6(FALSE)
+|                    [00000200D5D5CCE0][3]: (def[0]: 00000200D5D5B6F0) IROP_LT (def[0]: 00000200D5D5ACD0)
+|                    [00000200D5D5C560][3]: (null) IROP_TEST (null)
+|                node[4] <RETURN> -> 5
+|                    [00000200D5D5D020][4]: (li: 0x9{9}) IROP_STORE (null)
+|                    [00000200D5D5CEE0][4]: (def[0]: 00000200D5D5D680) <- (inst: 00000200D5D5D020) IROP_ASN (null)
+|                    [00000200D5D5D160][4]: (def[1]: 00000200D5D5B590) <- (def[0]: 00000200D5D5B590) IROP_ADD (li: 0x2{2})
+|                    [00000200D5D5D2E0][4]: (def[0]: 00000200D5D5E3E0) <- (null) IROP_INIT (null)
+|                    [00000200D5D5CDA0][4]: (def[1]: 00000200D5D5B590) IROP_MUL (li: 0x9{9})
+|                    [00000200D5D5CE20][4]: (def[0]: 00000200D5D5D680) IROP_SUB (inst: 00000200D5D5CDA0)
+|                    [00000200D5D5C9E0][4]: (def[1]: 00000200D5D5D680) <- (inst: 00000200D5D5CE20) IROP_ASN (null)
+|                    [00000200D5D5C5E0][4]: (def[0]: 00000200D5D5E3E0) IROP_STORE (null)
+|                    [00000200D5D5C9A0][4]: (inst: 00000200D5D5C5E0) IROP_RET (null)
+|                node[5] <ANY> -> 2
+|                    (no instructions)
+|                node[6] <RETURN> -> 5
+|                    [00000200D5D5CDE0][6]: (def[1]: 00000200D5D5A800) IROP_STORE (null)
+|                    [00000200D5D5CBA0][6]: (inst: 00000200D5D5CDE0) IROP_RET (null)
+>>>>> SUMMARY <<<<<
+node count: 7
+node arr size: 8
+edge count: 8
+edge arr size: 8
+instruction count: 23
+memory size: 2416 bytes
+
+            MyPackageClass: def constructor, Access: No Modifier, Parameter Count: 0(), Return: (null)
+>                Definition Pool: 0 definition(s), 40 byte(s)
+|                node[0] (entry point) <ANY>
+|                    (no instructions)
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 0
+memory size: 168 bytes
+
+            s: def member var, order 3, Access: No Modifier, Type: String
+            r2: def member var, order 0, Access: No Modifier, Type: JLT_RWD_INT
+            MyPackageClassI: def constructor, Access: No Modifier, Parameter Count: 1(I), Return: (null)
+>                Definition Pool: 1 definition(s), 200 byte(s)
+>                    [0](00000200D5D5E070): def var, Access: No Modifier, Type: JLT_RWD_INT
+|                node[0] (entry point) <ANY>
+|                    [00000200D5D5CA60][0]: (def[1]: 00000200D5D50E90) <- (def[0]: 00000200D5D5E070) IROP_ASN (null)
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 1
+memory size: 224 bytes
+
+            r3: def member var, order 1, Access: No Modifier, Type: JLT_RWD_INT
+            r4: def member var, order 2, Access: No Modifier, Type: JLT_RWD_SHORT
+
+*       Literals: 10 literal(s)
+            1: number, 0x1
+            9: number, 0x9
+            7: number, 0x7
+            5: number, 0x5
+            0: number, 0x0
+            3: number, 0x3
+            "Hello, World!": string, 26 byte(s), no wide character
+                            HEX             |  CHAR
+                ----------------------------+--------
+                00 48 00 65    00 6C 00 6C   .H.e.l.l
+                00 6F 00 2C    00 20 00 57   .o.,...W
+                00 6F 00 72    00 6C 00 64   .o.r.l.d
+                00 21                        .!
+
+            2: number, 0x2
+            6: number, 0x6
+            4: number, 0x4
+
+    SomeOtherClass: Access: No Modifier
+*       Member Variable Initialization:
+>            Definition Pool: 0 definition(s), 40 byte(s)
+|            node[0] (entry point) <ANY>
+|                [00000200D5D5CFA0][0]: (li: 0x1{1}) IROP_STORE (null)
+|                [00000200D5D5D0E0][0]: (def[0]: 00000200D5D5AC20) <- (inst: 00000200D5D5CFA0) IROP_ASN (null)
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 2
+memory size: 280 bytes
+
+*       Member: 1 member(s)
+            a: def member var, order 0, Access: No Modifier, Type: JLT_RWD_INT
+
+*       Literals: 1 literal(s)
+            1: number, 0x1
+
+
+===== LOOKUP STACK =====
+(lookup stack is empty)
+Press any key to continue . . .

--- a/parser.c
+++ b/parser.c
@@ -2411,7 +2411,7 @@ static tree_node* parse_constructor_declaration(java_parser* parser)
     tree_node* node = ast_node_constructor_declaration();
 
     // ID (
-    consume_token(parser, node->data->id.complex);
+    consume_token(parser, node->data->declarator.id.complex);
     consume_token(parser, NULL);
 
     // [FormalParameterList]

--- a/string-list.c
+++ b/string-list.c
@@ -61,6 +61,24 @@ void string_list_append(string_list* sl, char* str_data, bool copy)
     sl->count++;
 }
 
+/**
+ * append element by passing a character
+ *
+*/
+void string_list_append_char(string_list* sl, char c)
+{
+    if (!c)
+    {
+        return;
+    }
+
+    char* s = (char*)malloc_assert(sizeof(char) * 2);
+    s[0] = c;
+    s[1] = '\0';
+
+    string_list_append(sl, s, false);
+}
+
 // pop front
 char* string_list_pop_front(string_list* sl)
 {
@@ -83,8 +101,8 @@ char* string_list_pop_front(string_list* sl)
 /**
  * concat all strings with delimiter
  *
- * delimiter can be NULL, in this case, strings are separated
- * by '\0'
+ * when dlim = NULL, atring are concatenation without any separator
+ * when dlim[0] = '\0', strings are separated by '\0'
  *
  * if list is empty, it returns NULL
 */
@@ -96,7 +114,7 @@ char* string_list_concat(string_list* sl, const char* dlim)
     char* s;
     char* p;
     bool has_dlim = dlim && dlim[0] != '\0';
-    size_t dlen = has_dlim ? strlen(dlim) : 1;
+    size_t dlen = dlim == NULL ? 0 : (dlim[0] == '\0' ? 1 : strlen(dlim));
     size_t total_length = (sl->count - 1) * dlen;
     size_t total_size;
 
@@ -130,7 +148,7 @@ char* string_list_concat(string_list* sl, const char* dlim)
                 strcpy(p, dlim);
             }
 
-            // if no dlim, simply move pointer by 1 char leaving a \0 in-between
+            // if dlim = '\0', simply move pointer by 1 char leaving a \0 in-between
             p += dlen;
         }
     }

--- a/string-list.h
+++ b/string-list.h
@@ -25,6 +25,7 @@ typedef struct _string_list
 void init_string_list(string_list* sl);
 void release_string_list(string_list* sl);
 void string_list_append(string_list* sl, char* str_data, bool copy);
+void string_list_append_char(string_list* sl, char c);
 char* string_list_pop_front(string_list* sl);
 char* string_list_concat(string_list* sl, const char* dlim);
 char** string_list_to_string_array(string_list* sl);

--- a/test/il.txt
+++ b/test/il.txt
@@ -11,7 +11,13 @@ class MyPackageClass extends C1 implements C2, C3 {
     short r4;
     String s = "Hello, World!";
 
-    private int calc(int x, int y, short r2) {
+    MyPackageClass() {}
+    
+    MyPackageClass(int r) {
+        r2 = r;
+    }
+
+    private int calc(int x, int y, String.Impl sr1, short r2) {
         if (2 > 1)
         {
             x + y;

--- a/tree.c
+++ b/tree.c
@@ -71,13 +71,13 @@ void tree_node_delete(tree_node* node)
             case JNT_INTERFACE_TYPE_UNIT:
             case JNT_CLASS_DECL:
             case JNT_INTERFACE_DECL:
-            case JNT_CTOR_DECL:
             case JNT_PRIMARY_COMPLEX:
             case JNT_STATEMENT_BREAK:
             case JNT_STATEMENT_CONTINUE:
             case JNT_STATEMENT_LABEL:
                 free(node->data->id.complex);
                 break;
+            case JNT_CTOR_DECL:
             case JNT_METHOD_HEADER:
             case JNT_FORMAL_PARAM:
             case JNT_VAR_DECL:


### PR DESCRIPTION
* Implemented function overloading for methods and constructors
* Implemented constructor walk

Method name mangling in IR frontend shares same naming convension as IR backend, except that reference names are not fully qualified and verified yet.
| Prefix |      Format     |         Type        |
|:------:|:---------------:|:-------------------:|
|    B   |       `B`       |         byte        |
|    Z   |       `Z`       |       boolean       |
|    C   |       `C`       |         char        |
|    S   |       `S`       |        short        |
|    I   |       `I`       |         int         |
|    F   |       `F`       |        float        |
|    J   |       `J`       |         long        |
|    D   |       `D`       |        double       |
|    L   | `L ClassName ;` |   (reference type)  |
|    [   |       `[`       | (one array dimension) |
|    V   |       `V`       |         void        |

For example: definition `calc(int x, int y, String sr1, short r2)` will generate a name `calcIILString;S`