### PR TITLE
Refactor Definition Data

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -1487,8 +1487,8 @@ static void debug_print_reference(reference* r)
             break;
         case IR_ASN_REF_LITERAL:
             d = r->doi;
-            n = d->li_number.imm;
-            switch (d->li_number.type)
+            n = d->li_number->imm;
+            switch (d->li_number->type)
             {
                 case IRPV_INTEGER_BIT_8:
                     printf("(li: 0x%llx{%d})", n, (int8_t)n);
@@ -1648,7 +1648,7 @@ static void debug_print_definition(definition* v, size_t depth)
     switch (v->type)
     {
         case DEFINITION_VARIABLE:
-            if (v->variable.is_class_member)
+            if (v->variable->is_class_member)
             {
                 printf("def member var, order %zd, ", v->sid);
             }
@@ -1658,41 +1658,41 @@ static void debug_print_definition(definition* v, size_t depth)
             }
 
             printf("Access: ");
-            debug_print_modifier_bit_flag(v->variable.modifier);
+            debug_print_modifier_bit_flag(v->variable->modifier);
 
             printf(", Type: ");
-            if (v->variable.type.primitive != JLT_MAX)
+            if (v->variable->type.primitive != JLT_MAX)
             {
-                debug_print_lexeme_type(v->variable.type.primitive);
+                debug_print_lexeme_type(v->variable->type.primitive);
             }
             else
             {
-                printf("%s", v->variable.type.reference);
+                printf("%s", v->variable->type.reference);
             }
 
             printf("\n");
             break;
         case DEFINITION_METHOD:
-            printf("def %s, ", v->method.is_constructor ? method_ctor : method_regular);
+            printf("def %s, ", v->method->is_constructor ? method_ctor : method_regular);
 
             printf("Access: ");
-            debug_print_modifier_bit_flag(v->method.modifier);
+            debug_print_modifier_bit_flag(v->method->modifier);
 
-            printf(", Parameter Count: %zd(", v->method.parameter_count);
-            for (size_t i = 0; i < v->method.parameter_count; i++)
+            printf(", Parameter Count: %zd(", v->method->parameter_count);
+            for (size_t i = 0; i < v->method->parameter_count; i++)
             {
                 if (i > 0) { printf(" "); }
 
-                lex_type = v->method.parameters[i]->variable.type.primitive;
+                lex_type = v->method->parameters[i]->variable->type.primitive;
 
-                for (size_t j = v->method.parameters[i]->variable.type.dim; j > 0; j--)
+                for (size_t j = v->method->parameters[i]->variable->type.dim; j > 0; j--)
                 {
                     printf("[");
                 }
 
                 if (lex_type == JLT_MAX)
                 {
-                    printf("L%s;", v->method.parameters[i]->variable.type.reference);
+                    printf("L%s;", v->method->parameters[i]->variable->type.reference);
                 }
                 else
                 {
@@ -1702,34 +1702,34 @@ static void debug_print_definition(definition* v, size_t depth)
             printf(")");
 
             printf(", Return: ");
-            if (v->method.return_type.primitive != JLT_MAX)
+            if (v->method->return_type.primitive != JLT_MAX)
             {
-                debug_print_lexeme_type(v->method.return_type.primitive);
+                debug_print_lexeme_type(v->method->return_type.primitive);
             }
             else
             {
-                printf("%s", v->method.return_type.reference);
+                printf("%s", v->method->return_type.reference);
             }
 
             printf("\n");
 
-            debug_print_definition_pool(&v->method.local_variables, depth + 1);
-            debug_print_cfg(&v->method.code, depth + 1);
+            debug_print_definition_pool(&v->method->local_variables, depth + 1);
+            debug_print_cfg(&v->method->code, depth + 1);
 
             printf("\n");
             break;
         case DEFINITION_NUMBER:
-            printf("number, 0x%llx\n", v->li_number.imm);
+            printf("number, 0x%llx\n", v->li_number->imm);
             break;
         case DEFINITION_CHARACTER:
-            printf("character, 0x%llx (16-bit wide-char)\n", v->li_number.imm);
+            printf("character, 0x%llx (16-bit wide-char)\n", v->li_number->imm);
             break;
         case DEFINITION_BOOLEAN:
-            printf("boolean, 0x%llx (%s)\n", v->li_number.imm, v->li_number.imm ? "true" : "false");
+            printf("boolean, 0x%llx (%s)\n", v->li_number->imm, v->li_number->imm ? "true" : "false");
             break;
         case DEFINITION_STRING:
-            printf("string, %zd byte(s), %s wide character\n", v->li_string.length, v->li_string.wide_char ? "has" : "no");
-            __format_print_binary_stream(v->li_string.stream, v->li_string.length, depth + 1);
+            printf("string, %zd byte(s), %s wide character\n", v->li_string->length, v->li_string->wide_char ? "has" : "no");
+            __format_print_binary_stream(v->li_string->stream, v->li_string->length, depth + 1);
             printf("\n");
             break;
         case DEFINITION_NULL:

--- a/ir-defuse.c
+++ b/ir-defuse.c
@@ -86,7 +86,7 @@ definition* def(
      * this information is needed because the order of member variable declaration needs to be
      * preserved for object size calculation with struct padding
     */
-    if (tdef && tdef->variable.is_class_member)
+    if (tdef && tdef->variable->is_class_member)
     {
         if (!ir->working_top_level || lookup_top_level_scope(ir) != table)
         {
@@ -109,7 +109,7 @@ definition* def(
     */
     if (name_dims > 0)
     {
-        if (tdef->variable.type.dim != name_dims)
+        if (tdef->variable->type.dim != name_dims)
         {
             ir_error(ir, err_dim_amb);
         }
@@ -216,19 +216,19 @@ definition* def_li(
     {
         case JLT_LTR_NUMBER:
             v = new_definition(DEFINITION_NUMBER);
-            v->li_number.type = r2p(ir, *content, &bin, token_type, num_type, num_bits);
-            v->li_number.imm = bin.number;
+            v->li_number->type = r2p(ir, *content, &bin, token_type, num_type, num_bits);
+            v->li_number->imm = bin.number;
             break;
         case JLT_LTR_CHARACTER:
             v = new_definition(DEFINITION_CHARACTER);
-            v->li_number.type = r2p(ir, *content, &bin, token_type, num_type, num_bits);
-            v->li_number.imm = bin.number;
+            v->li_number->type = r2p(ir, *content, &bin, token_type, num_type, num_bits);
+            v->li_number->imm = bin.number;
             break;
         case JLT_RWD_TRUE:
         case JLT_RWD_FALSE:
             v = new_definition(DEFINITION_BOOLEAN);
-            v->li_number.type = r2p(ir, *content, &bin, token_type, num_type, num_bits);
-            v->li_number.imm = bin.number;
+            v->li_number->type = r2p(ir, *content, &bin, token_type, num_type, num_bits);
+            v->li_number->imm = bin.number;
             break;
         case JLT_RWD_NULL:
             // NULL has no aux data
@@ -237,9 +237,9 @@ definition* def_li(
         case JLT_LTR_STRING:
             v = new_definition(DEFINITION_STRING);
             r2p(ir, *content, &bin, token_type, num_type, num_bits);
-            v->li_string.stream = bin.stream;
-            v->li_string.length = bin.len;
-            v->li_string.wide_char = bin.wide_char;
+            v->li_string->stream = bin.stream;
+            v->li_string->length = bin.len;
+            v->li_string->wide_char = bin.wide_char;
             break;
         default:
             break;
@@ -301,28 +301,28 @@ definition* type2def(
     switch (type)
     {
         case DEFINITION_VARIABLE:
-            desc->variable.is_class_member = is_member;
-            desc->variable.modifier = modifier;
-            desc->variable.type.primitive = node->data->declarator.id.simple;
-            desc->variable.type.dim = node->data->declarator.dimension;
+            desc->variable->is_class_member = is_member;
+            desc->variable->modifier = modifier;
+            desc->variable->type.primitive = node->data->declarator.id.simple;
+            desc->variable->type.dim = node->data->declarator.dimension;
 
             // if not primitive type, then it must be a reference type
-            if (desc->variable.type.primitive == JLT_MAX)
+            if (desc->variable->type.primitive == JLT_MAX)
             {
                 // type->class_type->unit
-                desc->variable.type.reference = name_unit_concat(node->first_child->first_child, NULL);
+                desc->variable->type.reference = name_unit_concat(node->first_child->first_child, NULL);
             }
             break;
         case DEFINITION_METHOD:
-            desc->method.modifier = modifier;
-            desc->method.return_type.primitive = node->data->declarator.id.simple;
-            desc->method.return_type.dim = node->data->declarator.dimension;
+            desc->method->modifier = modifier;
+            desc->method->return_type.primitive = node->data->declarator.id.simple;
+            desc->method->return_type.dim = node->data->declarator.dimension;
 
             // if not primitive type, then it must be a reference type
-            if (desc->method.return_type.primitive == JLT_MAX)
+            if (desc->method->return_type.primitive == JLT_MAX)
             {
                 // type->class_type->unit
-                desc->method.return_type.reference = name_unit_concat(node->first_child->first_child, NULL);
+                desc->method->return_type.reference = name_unit_concat(node->first_child->first_child, NULL);
             }
             break;
         default:
@@ -508,11 +508,11 @@ static void def_constructor(java_ir* ir, tree_node* node, lbit_flag modifier)
 
     if (method)
     {
-        method->method.is_constructor = true;
-        method->method.modifier = modifier;
+        method->method->is_constructor = true;
+        method->method->modifier = modifier;
         method->root_code_walk = node;
-        method->method.parameter_count = param_count;
-        method->method.parameters = (definition**)malloc_assert(sizeof(definition*) * param_count);
+        method->method->parameter_count = param_count;
+        method->method->parameters = (definition**)malloc_assert(sizeof(definition*) * param_count);
     }
 
     // cleanup
@@ -723,8 +723,8 @@ static void def_method(java_ir* ir, tree_node* node, lbit_flag modifier)
          * of entire method: JNT_METHOD_DECL
         */
         method->root_code_walk = node_method_decl;
-        method->method.parameter_count = param_count;
-        method->method.parameters = (definition**)malloc_assert(sizeof(definition*) * param_count);
+        method->method->parameter_count = param_count;
+        method->method->parameters = (definition**)malloc_assert(sizeof(definition*) * param_count);
     }
 
     // cleanup

--- a/ir-walk.c
+++ b/ir-walk.c
@@ -1304,7 +1304,7 @@ static void walk_constructor(java_ir* ir, definition* ctor_def)
     // fill all parameter declarations
     if (node->type == JNT_FORMAL_PARAM_LIST)
     {
-        def_params(ir, node, ctor_def->method.parameters);
+        def_params(ir, node, ctor_def->method->parameters);
         node = node->next_sibling;
     }
 
@@ -1318,7 +1318,7 @@ static void walk_constructor(java_ir* ir, definition* ctor_def)
     cfg_worker_ssa_build(worker);
 
     // release worker
-    release_cfg_worker(worker, &ctor_def->method.code, &ctor_def->method.local_variables);
+    release_cfg_worker(worker, &ctor_def->method->code, &ctor_def->method->local_variables);
     free(worker);
 }
 
@@ -1415,7 +1415,7 @@ static void walk_method(java_ir* ir, definition* method_def)
     lookup_new_scope(ir);
 
     // fill all parameter declarations
-    def_params(ir, node->first_child, method_def->method.parameters);
+    def_params(ir, node->first_child, method_def->method->parameters);
 
     // parse body (use current scope)
     worker = walk_block(ir, node->next_sibling, false);
@@ -1427,7 +1427,7 @@ static void walk_method(java_ir* ir, definition* method_def)
     cfg_worker_ssa_build(worker);
 
     // release worker
-    release_cfg_worker(worker, &method_def->method.code, &method_def->method.local_variables);
+    release_cfg_worker(worker, &method_def->method->code, &method_def->method->local_variables);
     free(worker);
 }
 
@@ -1475,7 +1475,7 @@ void walk_class(java_ir* ir, global_top_level* class)
                     walk_field(ir, desc, &member_init_worker);
                     break;
                 case DEFINITION_METHOD:
-                    if (desc->method.is_constructor)
+                    if (desc->method->is_constructor)
                     {
                         walk_constructor(ir, desc);
                     }

--- a/ir.h
+++ b/ir.h
@@ -313,6 +313,51 @@ typedef enum
     DEFINITION_STRING,
 } definition_type;
 
+typedef struct
+{
+    // if it is a member variable
+    bool is_class_member;
+    // modifier
+    lbit_flag modifier;
+    // type
+    type_name type;
+} definition_variable;
+
+typedef struct
+{
+    // modifier
+    lbit_flag modifier;
+    // if method is a constructor
+    bool is_constructor;
+    // parameter count
+    size_t parameter_count;
+    // ordered parameter definition
+    definition** parameters;
+    // return type
+    type_name return_type;
+    // code
+    cfg code;
+    definition_pool local_variables;
+} definition_method;
+
+typedef struct
+{
+    // primitive type
+    primitive type;
+    // literal value
+    uint64_t imm;
+} definition_number;
+
+typedef struct
+{
+    // 16-bit character binary stream
+    char* stream;
+    // number of bytes of stream
+    size_t length;
+    // if stream contains 16-bit wide character
+    bool wide_char;
+} definition_string;
+
 /**
  * scope lookup table value descriptor
  *
@@ -329,52 +374,14 @@ typedef struct _definition
     // internal-only: the code walk root
     tree_node* root_code_walk;
 
+    // typed definition data access
+    // pointer-only here!
     union
     {
-        struct
-        {
-            // if it is a member variable
-            bool is_class_member;
-            // modifier
-            lbit_flag modifier;
-            // type
-            type_name type;
-        } variable;
-
-        struct
-        {
-            // modifier
-            lbit_flag modifier;
-            // if method is a constructor
-            bool is_constructor;
-            // parameter count
-            size_t parameter_count;
-            // ordered parameter definition
-            struct _definition** parameters;
-            // return type
-            type_name return_type;
-            // code
-            cfg code;
-            definition_pool local_variables;
-        } method;
-
-        struct
-        {
-            // primitive type
-            primitive type;
-            // literal value
-            uint64_t imm;
-        } li_number;
-
-        struct
-        {
-            // 16-bit character binary stream
-            char* stream;
-            // number of bytes of stream
-            size_t length;
-            // if stream contains 16-bit wide character
-            bool wide_char;
-        } li_string;
+        definition_variable* variable;
+        definition_method* method;
+        definition_number* li_number;
+        definition_string* li_string;
     };
 } definition;
 


### PR DESCRIPTION
As definition data for each specific type have grown overly complex, `definition` may not be space efficient, so every struct in the union are moved out as stand-alone struct, and referenced by `definition` using pointer. In this way the `union` size becomes stable (always size of one pointer), and the access for specifc data can still be well-typed.