### PR TITLE
Expression Worker V2: Logical Operator

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -1427,6 +1427,9 @@ static void debug_print_irop(operation irop)
         case IROP_NOOP:
             printf("IROP_NOOP");
             break;
+        case IROP_BOOL:
+            printf("IROP_BOOL");
+            break;
         case IROP_MAX:
             printf("(Invalid: IROP_MAX)");
             break;

--- a/expression.c
+++ b/expression.c
@@ -145,6 +145,11 @@ void init_expression(java_expression* expression)
      *
      * NOTE: composite assignment operators are reduced by stripping the
      * "assignment" part
+     *
+     * NOTE: logical AND and OR have no instruction mapping as they have
+     * short-circuit evaluation and hence will be expanded on logical level;
+     * by default: it will be bit-wise AND to cover optimized minimum case,
+     * where both operands are Primary
     */
 
     expression->ir_map[0] = IROP_UNDEFINED;
@@ -174,8 +179,8 @@ void init_expression(java_expression* expression)
     expression->ir_map[OPID_BIT_AND] = IROP_BAND;
     expression->ir_map[OPID_BIT_XOR] = IROP_XOR;
     expression->ir_map[OPID_BIT_OR] = IROP_BOR;
-    expression->ir_map[OPID_LOGIC_AND] = IROP_LAND;
-    expression->ir_map[OPID_LOGIC_OR] = IROP_LOR;
+    expression->ir_map[OPID_LOGIC_AND] = IROP_BAND;
+    expression->ir_map[OPID_LOGIC_OR] = IROP_BOR;
     expression->ir_map[OPID_TERNARY_1] = IROP_TC;
     expression->ir_map[OPID_TERNARY_2] = IROP_TB;
     expression->ir_map[OPID_ASN] = IROP_ASN;
@@ -184,9 +189,9 @@ void init_expression(java_expression* expression)
     expression->ir_map[OPID_MUL_ASN] = IROP_MUL;
     expression->ir_map[OPID_DIV_ASN] = IROP_DIV;
     expression->ir_map[OPID_MOD_ASN] = IROP_MOD;
-    expression->ir_map[OPID_AND_ASN] = IROP_LAND;
+    expression->ir_map[OPID_AND_ASN] = IROP_BAND;
     expression->ir_map[OPID_XOR_ASN] = IROP_XOR;
-    expression->ir_map[OPID_OR_ASN] = IROP_LOR;
+    expression->ir_map[OPID_OR_ASN] = IROP_BOR;
     expression->ir_map[OPID_SHIFT_L_ASN] = IROP_SLS;
     expression->ir_map[OPID_SHIFT_R_ASN] = IROP_SRS;
     expression->ir_map[OPID_SHIFT_UR_ASN] = IROP_URS;

--- a/expression.h
+++ b/expression.h
@@ -129,6 +129,7 @@ typedef unsigned short java_operator;
  * IROP_TEST    test-and-jump
  * IROP_PHI     branch convergence selector
  * IROP_NOOP    no-op, but occupies an instruction
+ * IROP_BOOL    cast a value to boolean data
 */
 typedef enum
 {
@@ -200,6 +201,7 @@ typedef enum
     IROP_TEST,
     IROP_PHI,
     IROP_NOOP,
+    IROP_BOOL,
 
     IROP_MAX,
 } operation;

--- a/output/2024-04-06.txt
+++ b/output/2024-04-06.txt
@@ -1,0 +1,385 @@
+===== COMPILER RUNTIME REPORT =====
+Language version: 1
+Reserved word:
+    count: 50
+    memory: 4824 bytes
+    load factor: 14.16%
+    longest chain: 1
+Expression static data size: 1072 bytes
+Error static data size: 601 bytes
+===== END OF REPORT =====
+
+File 1: ./test/il.txt
+all dominator sets:
+0: 0
+1: 0 1
+2: 2 0
+3: 0 3
+4: 0 3 4
+5: 0 3 5
+6: 0 3 6
+all DF sets:
+0:
+1: 2
+2:
+3: 2
+4: 5
+5: 2
+6: 5
+all dominator sets:
+0: 0
+all DF sets:
+0:
+all dominator sets:
+0: 0
+all DF sets:
+0:
+===== ABSTRACT SYNTAX TREE =====
+Compilation Unit
+  Package Declaration
+    Name
+      Unit: mypack
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: text
+      Unit: DecimalFormat
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: util
+      Unit: InputMismatchException
+  Import Declaration (On-demand: false)
+    Name
+      Unit: java
+      Unit: util
+      Unit: Scanner
+  Import Declaration (On-demand: true)
+    Name
+      Unit: somepackage
+  Top Level: No Modifier
+    Class Declaration: MyPackageClass
+      Class Extends
+        Class Type
+          Unit: C1
+      Class Implements
+        Interface Type List
+          Interface Type
+            Unit: C2
+          Interface Type
+            Unit: C3
+      Class Body
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_INT
+          Variable Declarators
+            Variable Declarator: r2
+              Expression OP[29]: OPID_TERNARY_1 -> JLT_SYM_QUESTION "?"
+                Expression OP[27]: OPID_LOGIC_AND -> JLT_SYM_LOGIC_AND "&&"
+                  Expression OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                    Primary
+                      1
+                    Primary
+                      2
+                  Expression OP[17]: OPID_LESS -> JLT_SYM_ANGLE_BRACKET_OPEN "<"
+                    Primary
+                      3
+                    Primary
+                      4
+                Expression OP[29]: OPID_TERNARY_1 -> JLT_SYM_QUESTION "?"
+                  Expression OP[22]: OPID_EQ -> JLT_SYM_RELATIONAL_EQUAL "=="
+                    Primary
+                      5
+                    Primary
+                      6
+                  Primary
+                    7
+                  Primary
+                    8
+                Primary
+                  9
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_INT
+          Variable Declarators
+            Variable Declarator: r3
+              Primary
+                0
+        Class Body Declaration: No Modifier
+          Type: JLT_RWD_SHORT
+          Variable Declarators
+            Variable Declarator: r4
+        Class Body Declaration: No Modifier
+          Type: (Complex Type Shown In Sub-Tree)
+            Class Type
+              Unit: String
+          Variable Declarators
+            Variable Declarator: s
+              Primary
+                "Hello, World!"
+        Class Body Declaration: No Modifier
+          Constructor Declaration: MyPackageClass
+            Constructor Body
+        Class Body Declaration: No Modifier
+          Constructor Declaration: MyPackageClass
+            Formal Parameter List
+              Formal Parameter: r
+                Type: JLT_RWD_INT
+            Constructor Body
+              Expression Statement
+                Expression OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+                  Primary
+                    r2
+                  Primary
+                    r
+        Class Body Declaration: private
+          Type: JLT_RWD_INT
+          Method Declaration
+            Method Header: calc
+              Formal Parameter List
+                Formal Parameter: x
+                  Type: JLT_RWD_INT
+                Formal Parameter: y
+                  Type: JLT_RWD_INT
+                Formal Parameter: sr1
+                  Type: (Complex Type Shown In Sub-Tree)
+                    Class Type
+                      Unit: String
+                      Unit: Impl
+                Formal Parameter: r2
+                  Type: JLT_RWD_SHORT
+            Method Body
+              Block
+                If Statement
+                  Expression OP[19]: OPID_GREAT -> JLT_SYM_ANGLE_BRACKET_CLOSE ">"
+                    Primary
+                      2
+                    Primary
+                      1
+                  Block
+                    Expression Statement
+                      Expression OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                        Primary
+                          x
+                        Primary
+                          y
+                    Expression Statement
+                      Expression OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+                        Primary
+                          r3
+                        Expression OP[12]: OPID_ADD -> JLT_SYM_PLUS "+"
+                          Expression OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                            Primary
+                              r2
+                            Primary
+                              6
+                          Primary
+                            y
+                    Return Statement
+                      Primary
+                        3
+                  If Statement
+                    Expression OP[17]: OPID_LESS -> JLT_SYM_ANGLE_BRACKET_OPEN "<"
+                      Primary
+                        r2
+                      Primary
+                        x
+                    Block
+                      Variable Declaration
+                        Local Variable Declaration
+                          Type: JLT_RWD_INT
+                          Variable Declarators
+                            Variable Declarator: tmp
+                              Primary
+                                9
+                      Expression Statement
+                        Expression OP[32]: OPID_ADD_ASN -> JLT_SYM_ADD_ASSIGNMENT "+="
+                          Primary
+                            y
+                          Primary
+                            2
+                      Variable Declaration
+                        Local Variable Declaration
+                          Type: JLT_RWD_INT
+                          Variable Declarators
+                            Variable Declarator: tmp2
+                      Expression Statement
+                        Expression OP[31]: OPID_ASN -> JLT_SYM_EQUAL "="
+                          Primary
+                            tmp
+                          Expression OP[13]: OPID_SUB -> JLT_SYM_MINUS "-"
+                            Primary
+                              tmp
+                            Expression OP[9]: OPID_MUL -> JLT_SYM_ASTERISK "*"
+                              Primary
+                                y
+                              Primary
+                                9
+                      Return Statement
+                        Primary
+                          tmp2
+                    Block
+                      Return Statement
+                        Primary
+                          r3
+                Return Statement
+                  Primary
+                    0
+
+===== IMPORTS =====
+count: 4
+memory: 248 bytes
+load factor: 36.36%
+longest chain: 2
+    somepackage: (ON-DEMAND)
+    Scanner: FROM java.util
+    DecimalFormat: FROM java.text
+    InputMismatchException: FROM java.util
+
+===== GLOBAL NAMES =====
+count: 1
+memory: 128 bytes
+load factor: 9.09%
+longest chain: 1
+    MyPackageClass: Access: No Modifier extends C1 implements: C2, C3
+*       Member Variable Initialization:
+>            Definition Pool: 0 definition(s), 40 byte(s)
+|            node[0] (entry point) <ANY> -> 1
+|                [000001CD8174C6A0][0]: (li: string [000001CD8174EE20]) IROP_STORE (null)
+|                [000001CD8174C2A0][0]: (def[0]: 000001CD817488C0) <- (inst: 000001CD8174C6A0) IROP_ASN (null)
+|            node[1] <TEST> -> 2(FALSE) -> 3(TRUE)
+|                [000001CD8174C860][1]: (li: 0x1{1}) IROP_GT (li: 0x2{2})
+|                [000001CD8174BFA0][1]: (inst: 000001CD8174C860) IROP_BOOL (null)
+|                [000001CD8174C7E0][1]: (null) IROP_TEST (null)
+|            node[2] <TEST> -> 4(TRUE) -> 9(FALSE)
+|                [000001CD8174C820][2]: (inst: 000001CD8174BFA0) IROP_PHI (inst: 000001CD8174CC60)
+|                [000001CD8174C220][2]: (null) IROP_TEST (null)
+|            node[3] <ANY> -> 2
+|                [000001CD8174C0E0][3]: (li: 0x3{3}) IROP_LT (li: 0x4{4})
+|                [000001CD8174CC60][3]: (inst: 000001CD8174C0E0) IROP_BOOL (null)
+|            node[4] <TEST> -> 5(TRUE) -> 7(FALSE)
+|                [000001CD8174C9E0][4]: (li: 0x5{5}) IROP_EQ (li: 0x6{6})
+|                [000001CD8174BDA0][4]: (null) IROP_TEST (null)
+|            node[5] <ANY> -> 6
+|                [000001CD8174CAE0][5]: (li: 0x7{7}) IROP_STORE (null)
+|            node[6] <ANY> -> 8
+|                [000001CD8174C520][6]: (inst: 000001CD8174CAE0) IROP_PHI (inst: 000001CD8174C5A0)
+|            node[7] <ANY> -> 6
+|                [000001CD8174C5A0][7]: (li: 0x8{8}) IROP_STORE (null)
+|            node[8] <ANY> -> 10
+|                [000001CD8174CA60][8]: (inst: 000001CD8174C520) IROP_PHI (inst: 000001CD8174BE60)
+|                [000001CD8174BFE0][8]: (def[0]: 000001CD81748A70) <- (inst: 000001CD8174CA60) IROP_ASN (null)
+|            node[9] <ANY> -> 8
+|                [000001CD8174BE60][9]: (li: 0x9{9}) IROP_STORE (null)
+|            node[10] <ANY>
+|                [000001CD8174CB20][10]: (li: 0x0{0}) IROP_STORE (null)
+|                [000001CD8174BEA0][10]: (def[0]: 000001CD81748770) <- (inst: 000001CD8174CB20) IROP_ASN (null)
+|                [000001CD8174CCA0][10]: (def[0]: 000001CD81748950) <- (null) IROP_INIT (null)
+>>>>> SUMMARY <<<<<
+node count: 11
+node arr size: 16
+edge count: 13
+edge arr size: 16
+instruction count: 20
+memory size: 2944 bytes
+
+*       Member: 7 member(s)
+            [000001CD8174A8F0] calcIILString.Impl;S: def method, Access: private, Parameter Count: 4(I I LString.Impl; S), Return: JLT_RWD_INT
+>                Definition Pool: 6 definition(s), 328 byte(s)
+>                    [0](000001CD8174AB90): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [1](000001CD8174AB30): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [2](000001CD8174A530): def var, Access: No Modifier, Type: JLT_RWD_SHORT
+>                    [3](000001CD8174A800): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [4](000001CD8174A620): def var, Access: No Modifier, Type: JLT_RWD_INT
+>                    [5](000001CD8174A920): def var, Access: No Modifier, Type: String.Impl
+|                node[0] (entry point) <TEST> -> 1(TRUE) -> 3(FALSE)
+|                    [000001CD81749A90][0]: (li: 0x2{2}) IROP_GT (li: 0x1{1})
+|                    [000001CD8174A150][0]: (null) IROP_TEST (null)
+|                node[1] <RETURN> -> 2
+|                    [000001CD8174A1D0][1]: (def[0]: 000001CD8174A620) IROP_ADD (def[0]: 000001CD8174A800)
+|                    [000001CD81749650][1]: (def[0]: 000001CD8174A530) IROP_SUB (li: 0x6{6})
+|                    [000001CD81749690][1]: (inst: 000001CD81749650) IROP_ADD (def[0]: 000001CD8174A800)
+|                    [000001CD8174A210][1]: (def[1]: 000001CD81748770) <- (inst: 000001CD81749690) IROP_ASN (null)
+|                    [000001CD81749790][1]: (li: 0x3{3}) IROP_STORE (null)
+|                    [000001CD81749810][1]: (inst: 000001CD81749790) IROP_RET (null)
+|                node[2] <RETURN>
+|                    [000001CD8174C320][2]: (li: 0x0{0}) IROP_STORE (null)
+|                    [000001CD8174C2E0][2]: (inst: 000001CD8174C320) IROP_RET (null)
+|                node[3] <TEST> -> 4(TRUE) -> 6(FALSE)
+|                    [000001CD8174A2D0][3]: (def[0]: 000001CD8174A530) IROP_LT (def[0]: 000001CD8174A620)
+|                    [000001CD8174A010][3]: (null) IROP_TEST (null)
+|                node[4] <RETURN> -> 5
+|                    [000001CD81749990][4]: (li: 0x9{9}) IROP_STORE (null)
+|                    [000001CD8174A310][4]: (def[0]: 000001CD8174AB30) <- (inst: 000001CD81749990) IROP_ASN (null)
+|                    [000001CD8174A350][4]: (def[1]: 000001CD8174A800) <- (def[0]: 000001CD8174A800) IROP_ADD (li: 0x2{2})
+|                    [000001CD8174A390][4]: (def[0]: 000001CD8174AB90) <- (null) IROP_INIT (null)
+|                    [000001CD817495D0][4]: (def[1]: 000001CD8174A800) IROP_MUL (li: 0x9{9})
+|                    [000001CD81749AD0][4]: (def[0]: 000001CD8174AB30) IROP_SUB (inst: 000001CD817495D0)
+|                    [000001CD81749B10][4]: (def[1]: 000001CD8174AB30) <- (inst: 000001CD81749AD0) IROP_ASN (null)
+|                    [000001CD81749B50][4]: (def[0]: 000001CD8174AB90) IROP_STORE (null)
+|                    [000001CD8174BE20][4]: (inst: 000001CD81749B50) IROP_RET (null)
+|                node[5] <ANY> -> 2
+|                    (no instructions)
+|                node[6] <RETURN> -> 5
+|                    [000001CD8174C560][6]: (def[1]: 000001CD81748770) IROP_STORE (null)
+|                    [000001CD8174C6E0][6]: (inst: 000001CD8174C560) IROP_RET (null)
+>>>>> SUMMARY <<<<<
+node count: 7
+node arr size: 8
+edge count: 8
+edge arr size: 8
+instruction count: 23
+memory size: 2416 bytes
+
+            [000001CD8174AA70] MyPackageClass: def constructor, Access: No Modifier, Parameter Count: 0(), Return: (null)
+>                Definition Pool: 0 definition(s), 40 byte(s)
+|                node[0] (entry point) <ANY>
+|                    (no instructions)
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 0
+memory size: 168 bytes
+
+            [000001CD817488C0] s: def member var, order 3, Access: No Modifier, Type: String
+            [000001CD81748A70] r2: def member var, order 0, Access: No Modifier, Type: JLT_RWD_INT
+            [000001CD8174A590] MyPackageClassI: def constructor, Access: No Modifier, Parameter Count: 1(I), Return: (null)
+>                Definition Pool: 1 definition(s), 80 byte(s)
+>                    [0](000001CD8174A6E0): def var, Access: No Modifier, Type: JLT_RWD_INT
+|                node[0] (entry point) <ANY>
+|                    [000001CD8174C020][0]: (def[1]: 000001CD81748A70) <- (def[0]: 000001CD8174A6E0) IROP_ASN (null)
+>>>>> SUMMARY <<<<<
+node count: 1
+node arr size: 2
+edge count: 0
+edge arr size: 2
+instruction count: 1
+memory size: 224 bytes
+
+            [000001CD81748770] r3: def member var, order 1, Access: No Modifier, Type: JLT_RWD_INT
+            [000001CD81748950] r4: def member var, order 2, Access: No Modifier, Type: JLT_RWD_SHORT
+
+*       Literals: 11 literal(s)
+            [000001CD8174A680] 1: number, 0x1
+            [000001CD8174A9B0] 9: number, 0x9
+            [000001CD8174AAD0] 7: number, 0x7
+            [000001CD8174EA00] 5: number, 0x5
+            [000001CD8174A7A0] 8: number, 0x8
+            [000001CD8174A500] 0: number, 0x0
+            [000001CD8174A770] 3: number, 0x3
+            [000001CD8174EE20] "Hello, World!": string, 26 byte(s), no wide character
+                            HEX             |  CHAR
+                ----------------------------+--------
+                00 48 00 65    00 6C 00 6C   .H.e.l.l
+                00 6F 00 2C    00 20 00 57   .o.,...W
+                00 6F 00 72    00 6C 00 64   .o.r.l.d
+                00 21                        .!
+
+            [000001CD8174A650] 2: number, 0x2
+            [000001CD8174AAA0] 6: number, 0x6
+            [000001CD8174ED60] 4: number, 0x4
+
+
+===== LOOKUP STACK =====
+(lookup stack is empty)
+Press any key to continue . . .


### PR DESCRIPTION
This is a follow-up PR of #71, to bring back logical expansion of logical operators in new expression worker architecture.

* new instruction `IROP_BOOL`: to help identify a value under evaluation of logical operator, so CFG will know this reference will be enforced to be a Boolean value
* walk algorithm for `OPID_LOGIC_AND` and `OPID_LOGIC_OR`: during initialization, there is an optimization that uses bit-wise `IROP` to do logical version if, and only if both operands are Primary; and the walk works similar as ternary operators
* fixed a bug in OPID-IROP mapping table: `&=` and `|=` were incorrectly mapped to logical version `IROP`, they are actually bit-wise