### PR TITLE
Error Logger V2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,15 @@
         "*.c": "c",
         "*.h": "c",
         "xstring": "c",
-        "xutility": "c"
+        "xutility": "c",
+        "initializer_list": "c",
+        "utility": "c",
+        "compare": "c",
+        "cstddef": "c",
+        "limits": "c",
+        "type_traits": "c",
+        "xmemory": "c",
+        "tuple": "c",
+        "xtr1common": "c"
     }
 }

--- a/compiler.h
+++ b/compiler.h
@@ -20,9 +20,10 @@ typedef struct
     hash_table rw_lookup_table;
     java_expression expression;
     java_error_definition err_def;
+    java_lexer lexer;
     java_parser context;
     java_ir ir;
-    java_error_stack error;
+    java_error_logger logger;
 } compiler;
 
 /**

--- a/debug.c
+++ b/debug.c
@@ -1,7 +1,7 @@
 #include "debug.h"
 
 #include "langspec.h"
-#include "token.h"
+#include "lexer.h"
 #include "node.h"
 #include "expression.h"
 #include "number.h"

--- a/debug.h
+++ b/debug.h
@@ -17,10 +17,11 @@ void debug_report(compiler* compiler);
 void debug_print_reserved_words();
 void debug_file_buffer(file_buffer* reader);
 void debug_print_symbol_table(hash_table* table);
-void debug_tokenize(file_buffer* buffer, hash_table* table);
+void debug_tokenize(file_buffer* buffer, hash_table* table, java_error_logger* logger);
 void debug_ast(java_parser* parser);
 void debug_java_symbol_lookup_table_no_collision_test(bool use_prime_size);
 void debug_print_global_import(java_ir* ir);
 void debug_ir_global_names(java_ir* ir);
+void debug_print_error_logger(java_error_logger* logger);
 
 #endif

--- a/error.c
+++ b/error.c
@@ -1,400 +1,669 @@
 #include "error.h"
 
+#define ERROR_DEFINITION_ENTRY(def, id, desc, ctx, msg) \
+    def[id] = (java_error_definition){ .descriptor = (desc), .context = (ctx), .message = (msg) }
+
 /**
  * Common Error Messages
 */
-static char* ERR_MSG_NO_SEMICOLON = "Expected ';'.";
-static char* ERR_MSG_NO_RIGHT_BRACE = "Expected '}'.";
-static char* ERR_MSG_NO_RIGHT_PARENTHESIS = "Expected ')'.";
-static char* ERR_MSG_NO_RIGHT_BRACKET = "Expected ']'.";
+
+static char* STR_NULL = "(null)";
+static char* ERR_CTX_PKG_DECL = "package declaration";
+static char* ERR_CTX_IMPORT_DECL = "import declaration";
+static char* ERR_CTX_CLASS_DECL = "class declaration";
+static char* ERR_CTX_INTERFACE_DECL = "interface declaration";
+static char* ERR_CTX_MEMBER_DECL = "member declaration";
+static char* ERR_CTX_VAR_DECL = "variable declaration";
+static char* ERR_CTX_EXPR = "expression";
+static char* ERR_MSG_MISSING_TOKEN = "Expected '%s' in %s.";
+static char* ERR_MSG_MISSING_STATEMENT_TOKEN = "Expected '%s' in %s statement.";
 static char* ERR_MSG_DIM_DEF_DIVERGE = "Dimension definition mismatched.";
 static char* ERR_MSG_DIM_DEF_DUPLICATE = "Duplicated dimension definition.";
 
 /**
  * Initialize Error Definitions
 */
-void init_error_definition(java_error_definition* err_def)
+static java_error_definition* new_error_definitions()
 {
-    err_def->descriptor = (error_descriptor*)malloc_assert(sizeof(error_descriptor) * JAVA_E_MAX);
-    err_def->message = (char**)malloc_assert(sizeof(char*) * JAVA_E_MAX);
+    java_error_definition* d = (java_error_definition*)malloc_assert(sizeof(java_error_definition) * JAVA_E_MAX);
 
-    /* Error Definitions */
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_RESERVED, DEFINE_RESERVED_ERROR, NULL, "(Unregistered error)");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NO_DIGIT, DEFINE_ERROR(JEL_ERROR, JES_LEXICAL), NULL, "At least one digit must be provided after prefix.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_ILLEGAL_CHARACTER, DEFINE_ERROR(JEL_ERROR, JES_LEXICAL), NULL, "Illegal character: '\\x%02x'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CHARACTER_LITERAL_ENCLOSE, DEFINE_ERROR(JEL_ERROR, JES_LEXICAL), "character literal", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STRING_LITERAL_ENCLOSE, DEFINE_ERROR(JEL_ERROR, JES_LEXICAL), "string literal", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MULTILINE_COMMENT_ENCLOSE, DEFINE_ERROR(JEL_ERROR, JES_LEXICAL), "multi-line comment", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_AMBIGUIOUS_ERROR_ENTRY, DEFINE_ERROR(JEL_ERROR, JES_INTERNAL), NULL, "Error stack contains ambiguous error entry, discarded...");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PASER_SWAP_FAILED, DEFINE_ERROR(JEL_ERROR, JES_INTERNAL), NULL, "Compiler is trying to swap an ill-formed parser instance.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PASER_DELETE_FAILED, DEFINE_ERROR(JEL_ERROR, JES_INTERNAL), NULL, "Compiler is trying to delete an ill-formed parser instance.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_AMBIGUITY_DIVERGE, DEFINE_ERROR(JEL_ERROR, JES_INTERNAL), NULL, "Ambiguity diverges: buffer has different cursor location: (0x%x, 0x%x).");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_FILE_NO_PATH, DEFINE_ERROR(JEL_ERROR, JES_RUNTIME), NULL, "File name is not valid.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_FILE_OPEN_FAILED, DEFINE_ERROR(JEL_ERROR, JES_RUNTIME), NULL, "File '%s' failed to open.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_FILE_SIZE_NOT_MATCH, DEFINE_ERROR(JEL_ERROR, JES_RUNTIME), NULL, "File '%s' has incorrect loading size comparing to what is reported from file system.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_TRAILING_CONTENT, DEFINE_ERROR(JEL_WARNING, JES_LEXICAL), NULL, "Unrecognized trailing content.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PKG_DECL_NO_NAME, DEFINE_SYNTAX_ERROR, ERR_CTX_PKG_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PKG_DECL_NO_SEMICOLON, DEFINE_SYNTAX_ERROR, ERR_CTX_PKG_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_IMPORT_NO_NAME, DEFINE_SYNTAX_ERROR, ERR_CTX_IMPORT_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_IMPORT_NO_SEMICOLON, DEFINE_SYNTAX_ERROR, ERR_CTX_IMPORT_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_IMPORT_AMBIGUOUS, DEFINE_CONTEXT_ERROR, ERR_CTX_IMPORT_DECL, "Ambiguous import type name, resolution of same type diverges.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_IMPORT_DUPLICATE, DEFINE_ERROR(JEL_WARNING, JES_CONTEXT), ERR_CTX_IMPORT_DECL, "Duplicated import, discarded.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_TOP_LEVEL, DEFINE_SYNTAX_ERROR, NULL, "Expected class or interface declaration.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CLASS_NO_NAME, DEFINE_SYNTAX_ERROR, ERR_CTX_CLASS_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CLASS_NO_BODY, DEFINE_SYNTAX_ERROR, ERR_CTX_CLASS_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CLASS_NAME_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, "Duplicated class name.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CLASS_BODY_ENCLOSE, DEFINE_CONTEXT_ERROR, "class body", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, java_E_CLASS_ENTENDS_NO_NAME, DEFINE_SYNTAX_ERROR, "class extends", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, java_E_CLASS_IMPLEMENTS_NO_NAME, DEFINE_SYNTAX_ERROR, "class implements", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_INTERFACE_NO_NAME, DEFINE_SYNTAX_ERROR, ERR_CTX_INTERFACE_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_INTERFACE_NO_BODY, DEFINE_SYNTAX_ERROR, ERR_CTX_INTERFACE_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, java_E_INTERFACE_ENTENDS_NO_NAME, DEFINE_SYNTAX_ERROR, "interface extends", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, java_E_INTERFACE_ENTENDS_NO_NAME, DEFINE_SYNTAX_ERROR, "interface body", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_VAR_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, "Duplicated member variable.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_VAR_DIM_AMBIGUOUS, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_DIM_DEF_DIVERGE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_VAR_DIM_DUPLICATE, DEFINE_ERROR(JEL_WARNING, JES_CONTEXT), NULL, ERR_MSG_DIM_DEF_DUPLICATE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_VAR_NO_SEMICOLON, DEFINE_SYNTAX_ERROR, "member variable declaration", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_METHOD_NO_SEMICOLON, DEFINE_SYNTAX_ERROR, "method interface", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_NO_TYPE, DEFINE_SYNTAX_ERROR, ERR_CTX_MEMBER_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_NO_NAME, DEFINE_SYNTAX_ERROR, ERR_CTX_MEMBER_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_MEMBER_AMBIGUOUS, DEFINE_SYNTAX_ERROR, NULL, "Incomplete member declaration.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATIC_INITIALIZER_NO_BODY, DEFINE_SYNTAX_ERROR, "static initializer", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_BLOCK_ENCLOSE, DEFINE_SYNTAX_ERROR, "block", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_UNRECOGNIZED, DEFINE_SYNTAX_ERROR, NULL, "Expected statement");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_SWITCH, DEFINE_SYNTAX_ERROR, "switch", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_DO, DEFINE_SYNTAX_ERROR, "do", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_BREAK, DEFINE_SYNTAX_ERROR, "break", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_CONTINUE, DEFINE_SYNTAX_ERROR, "continue", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_RETURN, DEFINE_SYNTAX_ERROR, "return", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_SYNCHRONIZED, DEFINE_SYNTAX_ERROR, "synchronized", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_THROW, DEFINE_SYNTAX_ERROR, "throw", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_TRY, DEFINE_SYNTAX_ERROR, "try", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_IF, DEFINE_SYNTAX_ERROR, "if", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_ELSE, DEFINE_SYNTAX_ERROR, "else clause", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_WHILE, DEFINE_SYNTAX_ERROR, "while", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_FOR, DEFINE_SYNTAX_ERROR, "for", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_FOR_INITIALIZER_NO_SEMICOLON, DEFINE_SYNTAX_ERROR, NULL, "Expected ';' after for-loop initializer.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_FOR_CONDITION_NO_SEMICOLON, DEFINE_SYNTAX_ERROR, NULL, "Expected ';' after for-loop condition.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_LABEL, DEFINE_SYNTAX_ERROR, "label", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_CATCH, DEFINE_SYNTAX_ERROR, "catch", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_FINALLY, DEFINE_SYNTAX_ERROR, "finally", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_STATEMENT_SWITCH_LABEL, DEFINE_SYNTAX_ERROR, "switch label", ERR_MSG_MISSING_STATEMENT_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CONSTRUCTOR, DEFINE_SYNTAX_ERROR, "constructor", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CONSTRUCTOR_INVOKE, DEFINE_SYNTAX_ERROR, "constructor invocation", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_METHOD_DECLARATION, DEFINE_SYNTAX_ERROR, "method declaration", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_METHOD_INVOKE, DEFINE_SYNTAX_ERROR, "method invocation", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_FORMAL_PARAMETER, DEFINE_SYNTAX_ERROR, "formal parameter", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_THROWS_NO_TYPE, DEFINE_SYNTAX_ERROR, "throws list", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NO_ARGUMENT, DEFINE_SYNTAX_ERROR, "argument list", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_ARRAY_INITIALIZER, DEFINE_SYNTAX_ERROR, "array initializer", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_ARRAY_CREATION, DEFINE_SYNTAX_ERROR, "array creation", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_ARRAY_ACCESS, DEFINE_SYNTAX_ERROR, "array access", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_OBJECT_CREATION, DEFINE_SYNTAX_ERROR, "object creation", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_INSTANCE_CREATION, DEFINE_SYNTAX_ERROR, "instance expression", ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_NO_OPERAND, DEFINE_SYNTAX_ERROR, NULL, "Invalid expression: expected operand.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_TOO_MANY_OPERAND, DEFINE_ERROR(JEL_ERROR, JES_INTERNAL), NULL, "Internal expression error: too many operands, they will be ignored.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_INCOMPLETE_TERNARY, DEFINE_SYNTAX_ERROR, NULL, "Invalid expression: incomplete conditional expression.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_UNHANDLED_BLOCK_CONTEXT, DEFINE_ERROR(JEL_ERROR, JES_INTERNAL), NULL, "Internal expression error: block context is not handled.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_NO_OPERATOR, DEFINE_SYNTAX_ERROR, NULL, "Invalid expression: expected operator.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_NO_LVALUE, DEFINE_SYNTAX_ERROR, NULL, "Invalid expression: expected lvalue.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_LITERAL_LVALUE, DEFINE_SYNTAX_ERROR, NULL, "Invalid expression: literal cannot be used as lvalue.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_NO_SEMICOLON, DEFINE_SYNTAX_ERROR, ERR_CTX_EXPR, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NUMBER_OVERFLOW_INT8, DEFINE_ERROR(JEL_WARNING, JES_SYNTAX), NULL, "Number overflows: literal value exceeds valid range of type 'byte'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NUMBER_OVERFLOW_INT16, DEFINE_ERROR(JEL_WARNING, JES_SYNTAX), NULL, "Number overflows: literal value exceeds valid range of type 'short'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NUMBER_OVERFLOW_INT32, DEFINE_ERROR(JEL_WARNING, JES_SYNTAX), NULL, "Number overflows: literal value exceeds valid range of type 'int'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NUMBER_OVERFLOW_INT64, DEFINE_ERROR(JEL_WARNING, JES_SYNTAX), NULL, "Number overflows: literal value exceeds valid range of type 'long'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NUMBER_OVERFLOW_U16, DEFINE_ERROR(JEL_WARNING, JES_SYNTAX), NULL, "Number overflows: literal value exceeds valid range of type 'char'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NUMBER_OVERFLOW_FP32_EXP, DEFINE_ERROR(JEL_WARNING, JES_SYNTAX), NULL, "Number overflows: floarting-point value exceeds valid range of type 'float'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_NUMBER_OVERFLOW_FP64_EXP, DEFINE_ERROR(JEL_WARNING, JES_SYNTAX), NULL, "Number overflows: floarting-point value exceeds valid range of type 'double'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PART_EXPONENT_OVERFLOW, DEFINE_CONTEXT_ERROR, NULL, "Invalid number: exponent part overflows.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PART_INTEGER_OVERFLOW, DEFINE_CONTEXT_ERROR, NULL, "Invalid number: too many digits.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_LOCAL_VAR_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, "Duplicated local variable name.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_LOCAL_VAR_DIM_AMBIGUOUS, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_DIM_DEF_DIVERGE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_LOCAL_VAR_DIM_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_DIM_DEF_DUPLICATE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_LOCAL_VAR_NO_SEMICOLON, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_VAR_NO_DECLARATOR, DEFINE_SYNTAX_ERROR, ERR_CTX_VAR_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_VAR_NO_ARR_ENCLOSE, DEFINE_SYNTAX_ERROR, ERR_CTX_VAR_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_VAR_NO_INITIALIZER, DEFINE_SYNTAX_ERROR, ERR_CTX_VAR_DECL, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PARAM_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, "Duplicated parameter name.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PARAM_DIM_AMBIGUOUS, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_DIM_DEF_DIVERGE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_PARAM_DIM_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_DIM_DEF_DUPLICATE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_METHOD_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, "Duplicated method name.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_METHOD_DIM_AMBIGUOUS, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_DIM_DEF_DIVERGE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_METHOD_DIM_DUPLICATE, DEFINE_CONTEXT_ERROR, NULL, ERR_MSG_DIM_DEF_DUPLICATE);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_IF_LOCAL_VAR_DECL, DEFINE_SYNTAX_ERROR, NULL, "Local variable definition not allowed in short 'if'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_WHILE_LOCAL_VAR_DECL, DEFINE_SYNTAX_ERROR, NULL, "Local variable definition not allowed in short 'while'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_REF_UNDEFINED, DEFINE_CONTEXT_ERROR, NULL, "Undefined reference.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_BREAK_UNBOUND, DEFINE_CONTEXT_ERROR, NULL, "Unbounded statement: 'break' needs to be bounded by a loop or 'switch'.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_CONTINUE_UNBOUND, DEFINE_CONTEXT_ERROR, NULL, "Unbounded statement: 'continue' needs to be bounded by a loop.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_LIST_INCOMPLETE, DEFINE_SYNTAX_ERROR, NULL, "Expected 'expression' in expression list.");
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_EXPRESSION_PARENTHESIS, DEFINE_SYNTAX_ERROR, ERR_CTX_EXPR, ERR_MSG_MISSING_TOKEN);
+    ERROR_DEFINITION_ENTRY(d, JAVA_E_TYPE_NO_ARR_ENCLOSE, DEFINE_SYNTAX_ERROR, ERR_CTX_EXPR, ERR_MSG_MISSING_TOKEN);
 
-    err_def->descriptor[JAVA_E_RESERVED] = DEFINE_RESERVED_ERROR;
-    err_def->descriptor[JAVA_E_FILE_NO_PATH] = DEFINE_ERROR(JEL_ERROR, JES_RUNTIME);
-    err_def->descriptor[JAVA_E_FILE_OPEN_FAILED] = DEFINE_ERROR(JEL_ERROR, JES_RUNTIME);
-    err_def->descriptor[JAVA_E_FILE_SIZE_NOT_MATCH] = DEFINE_ERROR(JEL_ERROR, JES_RUNTIME);
-    err_def->descriptor[JAVA_E_TRAILING_CONTENT] = DEFINE_ERROR(JEL_WARNING, JES_LEXICAL);
-    err_def->descriptor[JAVA_E_PKG_DECL_NO_NAME] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_PKG_DECL_NO_SEMICOLON] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_IMPORT_NO_NAME] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_IMPORT_NO_SEMICOLON] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_IMPORT_AMBIGUOUS] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_IMPORT_DUPLICATE] = DEFINE_ERROR(JEL_WARNING, JES_CONTEXT);
-    err_def->descriptor[JAVA_E_CLASS_NO_NAME] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_CLASS_NO_BODY] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_CLASS_NAME_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_CLASS_BODY_ENCLOSE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_MEMBER_VAR_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_MEMBER_VAR_DIM_AMBIGUOUS] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_MEMBER_VAR_DIM_DUPLICATE] = DEFINE_ERROR(JEL_WARNING, JES_CONTEXT);
-    err_def->descriptor[JAVA_E_MEMBER_VAR_NO_SEMICOLON] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_MEMBER_NO_TYPE] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_MEMBER_NO_NAME] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_MEMBER_AMBIGUOUS] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_NO_OPERAND] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_TOO_MANY_OPERAND] = DEFINE_ERROR(JEL_ERROR, JES_INTERNAL);
-    err_def->descriptor[JAVA_E_EXPRESSION_INCOMPLETE_TERNARY] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_UNHANDLED_BLOCK_CONTEXT] = DEFINE_ERROR(JEL_ERROR, JES_INTERNAL);
-    err_def->descriptor[JAVA_E_EXPRESSION_NO_OPERATOR] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_NO_LVALUE] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_LITERAL_LVALUE] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_NO_SEMICOLON] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_NUMBER_OVERFLOW_INT8] = DEFINE_ERROR(JEL_WARNING, JES_SYNTAX);
-    err_def->descriptor[JAVA_E_NUMBER_OVERFLOW_INT16] = DEFINE_ERROR(JEL_WARNING, JES_SYNTAX);
-    err_def->descriptor[JAVA_E_NUMBER_OVERFLOW_INT32] = DEFINE_ERROR(JEL_WARNING, JES_SYNTAX);
-    err_def->descriptor[JAVA_E_NUMBER_OVERFLOW_INT64] = DEFINE_ERROR(JEL_WARNING, JES_SYNTAX);
-    err_def->descriptor[JAVA_E_NUMBER_OVERFLOW_U16] = DEFINE_ERROR(JEL_WARNING, JES_SYNTAX);
-    err_def->descriptor[JAVA_E_NUMBER_OVERFLOW_FP32_EXP] = DEFINE_ERROR(JEL_WARNING, JES_SYNTAX);
-    err_def->descriptor[JAVA_E_NUMBER_OVERFLOW_FP64_EXP] = DEFINE_ERROR(JEL_WARNING, JES_SYNTAX);
-    err_def->descriptor[JAVA_E_PART_EXPONENT_OVERFLOW] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_PART_INTEGER_OVERFLOW] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_LOCAL_VAR_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_LOCAL_VAR_DIM_AMBIGUOUS] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_LOCAL_VAR_DIM_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_LOCAL_VAR_NO_SEMICOLON] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_VAR_NO_DECLARATOR] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_VAR_NO_ARR_ENCLOSE] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_VAR_NO_INITIALIZER] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_PARAM_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_PARAM_DIM_AMBIGUOUS] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_PARAM_DIM_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_METHOD_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_METHOD_DIM_AMBIGUOUS] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_METHOD_DIM_DUPLICATE] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_IF_LOCAL_VAR_DECL] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_WHILE_LOCAL_VAR_DECL] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_REF_UNDEFINED] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_BREAK_UNBOUND] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_CONTINUE_UNBOUND] = DEFINE_CONTEXT_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_LIST_INCOMPLETE] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_EXPRESSION_PARENTHESIS] = DEFINE_SYNTAX_ERROR;
-    err_def->descriptor[JAVA_E_TYPE_NO_ARR_ENCLOSE] = DEFINE_SYNTAX_ERROR;
-
-    err_def->descriptor[JAVA_E_AMBIGUITY_START] = DEFINE_RESERVED_ERROR;
-    err_def->descriptor[JAVA_E_AMBIGUITY_PATH_1] = DEFINE_RESERVED_ERROR;
-    err_def->descriptor[JAVA_E_AMBIGUITY_PATH_2] = DEFINE_RESERVED_ERROR;
-    err_def->descriptor[JAVA_E_AMBIGUITY_SEPARATOR] = DEFINE_RESERVED_ERROR;
-    err_def->descriptor[JAVA_E_AMBIGUITY_END] = DEFINE_RESERVED_ERROR;
-
-    /* Error Messages */
-
-    err_def->message[JAVA_E_RESERVED] = "(Unregistered error)";
-    err_def->message[JAVA_E_FILE_NO_PATH] = "File name is not valid.";
-    err_def->message[JAVA_E_FILE_OPEN_FAILED] = "File '%s' failed to open.";
-    err_def->message[JAVA_E_FILE_SIZE_NOT_MATCH] = "File '%s' has incorrect loading size comparing to what is reported from file system.";
-    err_def->message[JAVA_E_TRAILING_CONTENT] = "Unrecognized trailing content.";
-    err_def->message[JAVA_E_PKG_DECL_NO_NAME] = "Expected 'name' in package declaration.";
-    err_def->message[JAVA_E_PKG_DECL_NO_SEMICOLON] = ERR_MSG_NO_SEMICOLON;
-    err_def->message[JAVA_E_IMPORT_NO_NAME] = "Expected 'name' in import declaration.";
-    err_def->message[JAVA_E_IMPORT_NO_SEMICOLON] = ERR_MSG_NO_SEMICOLON;
-    err_def->message[JAVA_E_IMPORT_AMBIGUOUS] = "Ambiguous import type name, resolution of same type diverges.";
-    err_def->message[JAVA_E_IMPORT_DUPLICATE] = "Duplicated import, discarded.";
-    err_def->message[JAVA_E_CLASS_NO_NAME] = "Expected 'name' in class declaration.";
-    err_def->message[JAVA_E_CLASS_NO_BODY] = "Expected class body in class declaration.";
-    err_def->message[JAVA_E_CLASS_NAME_DUPLICATE] = "Duplicated class name.";
-    err_def->message[JAVA_E_CLASS_BODY_ENCLOSE] = ERR_MSG_NO_RIGHT_BRACE;
-    err_def->message[JAVA_E_MEMBER_VAR_DUPLICATE] = "Duplicated member variable.";
-    err_def->message[JAVA_E_MEMBER_VAR_DIM_AMBIGUOUS] = ERR_MSG_DIM_DEF_DIVERGE;
-    err_def->message[JAVA_E_MEMBER_VAR_DIM_DUPLICATE] = ERR_MSG_DIM_DEF_DUPLICATE;
-    err_def->message[JAVA_E_MEMBER_VAR_NO_SEMICOLON] = ERR_MSG_NO_SEMICOLON;
-    err_def->message[JAVA_E_MEMBER_NO_TYPE] = "Expected 'type' in member declaration.";
-    err_def->message[JAVA_E_MEMBER_NO_NAME] = "Expected 'name' in member declaration.";
-    err_def->message[JAVA_E_MEMBER_AMBIGUOUS] = "Incomplete member declaration.";
-    err_def->message[JAVA_E_EXPRESSION_NO_OPERAND] = "Invalid expression: expected operand.";
-    err_def->message[JAVA_E_EXPRESSION_TOO_MANY_OPERAND] = "Internal expression error: too many operands, they will be ignored.";
-    err_def->message[JAVA_E_EXPRESSION_INCOMPLETE_TERNARY] = "Invalid expression: incomplete conditional expression.";
-    err_def->message[JAVA_E_EXPRESSION_UNHANDLED_BLOCK_CONTEXT] = "Internal expression error: block context is not handled.";
-    err_def->message[JAVA_E_EXPRESSION_NO_OPERATOR] = "Invalid expression: expected operator.";
-    err_def->message[JAVA_E_EXPRESSION_NO_LVALUE] = "Invalid expression: expected lvalue.";
-    err_def->message[JAVA_E_EXPRESSION_LITERAL_LVALUE] = "Invalid expression: literal cannot be used as lvalue.";
-    err_def->message[JAVA_E_EXPRESSION_NO_SEMICOLON] = ERR_MSG_NO_SEMICOLON;
-    err_def->message[JAVA_E_NUMBER_OVERFLOW_INT8] = "Number overflows: literal value exceeds valid range of type 'byte'.";
-    err_def->message[JAVA_E_NUMBER_OVERFLOW_INT16] = "Number overflows: literal value exceeds valid range of type 'short'.";
-    err_def->message[JAVA_E_NUMBER_OVERFLOW_INT32] = "Number overflows: literal value exceeds valid range of type 'int'.";
-    err_def->message[JAVA_E_NUMBER_OVERFLOW_INT64] = "Number overflows: literal value exceeds valid range of type 'long'.";
-    err_def->message[JAVA_E_NUMBER_OVERFLOW_U16] = "Number overflows: literal value exceeds valid range of type 'char'.";
-    err_def->message[JAVA_E_NUMBER_OVERFLOW_FP32_EXP] = "Number overflows: floarting-point value exceeds valid range of type 'float'.";
-    err_def->message[JAVA_E_NUMBER_OVERFLOW_FP64_EXP] = "Number overflows: floarting-point value exceeds valid range of type 'double'.";
-    err_def->message[JAVA_E_PART_EXPONENT_OVERFLOW] = "Invalid number: exponent part overflows.";
-    err_def->message[JAVA_E_PART_INTEGER_OVERFLOW] = "Invalid number: too many digits.";
-    err_def->message[JAVA_E_LOCAL_VAR_DUPLICATE] = "Duplicated local variable name.";
-    err_def->message[JAVA_E_LOCAL_VAR_DIM_AMBIGUOUS] = ERR_MSG_DIM_DEF_DIVERGE;
-    err_def->message[JAVA_E_LOCAL_VAR_DIM_DUPLICATE] = ERR_MSG_DIM_DEF_DUPLICATE;
-    err_def->message[JAVA_E_LOCAL_VAR_NO_SEMICOLON] = ERR_MSG_NO_SEMICOLON;
-    err_def->message[JAVA_E_VAR_NO_DECLARATOR] = "Expected declarator name after type.";
-    err_def->message[JAVA_E_VAR_NO_ARR_ENCLOSE] = ERR_MSG_NO_RIGHT_BRACKET;
-    err_def->message[JAVA_E_VAR_NO_INITIALIZER] = "Expected variable initializer.";
-    err_def->message[JAVA_E_PARAM_DUPLICATE] = "Duplicated parameter name.";
-    err_def->message[JAVA_E_PARAM_DIM_AMBIGUOUS] = ERR_MSG_DIM_DEF_DIVERGE;
-    err_def->message[JAVA_E_PARAM_DIM_DUPLICATE] = ERR_MSG_DIM_DEF_DUPLICATE;
-    err_def->message[JAVA_E_METHOD_DUPLICATE] = "Duplicated method name.";
-    err_def->message[JAVA_E_METHOD_DIM_AMBIGUOUS] = ERR_MSG_DIM_DEF_DIVERGE;
-    err_def->message[JAVA_E_METHOD_DIM_DUPLICATE] = ERR_MSG_DIM_DEF_DUPLICATE;
-    err_def->message[JAVA_E_IF_LOCAL_VAR_DECL] = "Local variable definition not allowed in short 'if'.";
-    err_def->message[JAVA_E_WHILE_LOCAL_VAR_DECL] = "Local variable definition not allowed in short 'while'.";
-    err_def->message[JAVA_E_REF_UNDEFINED] = "Undefined reference.";
-    err_def->message[JAVA_E_BREAK_UNBOUND] = "Unbounded statement: 'break' needs to be bounded by a loop or 'switch'.";
-    err_def->message[JAVA_E_CONTINUE_UNBOUND] = "Unbounded statement: 'continue' needs to be bounded by a loop.";
-    err_def->message[JAVA_E_EXPRESSION_LIST_INCOMPLETE] = "Expected 'expression' in expression list.";
-    err_def->message[JAVA_E_EXPRESSION_PARENTHESIS] = ERR_MSG_NO_RIGHT_PARENTHESIS;
-    err_def->message[JAVA_E_TYPE_NO_ARR_ENCLOSE] = ERR_MSG_NO_RIGHT_BRACKET;
-
-    err_def->message[JAVA_E_AMBIGUITY_START] = NULL;
-    err_def->message[JAVA_E_AMBIGUITY_PATH_1] = NULL;
-    err_def->message[JAVA_E_AMBIGUITY_PATH_2] = NULL;
-    err_def->message[JAVA_E_AMBIGUITY_SEPARATOR] = NULL;
-    err_def->message[JAVA_E_AMBIGUITY_END] = NULL;
+    return d;
 }
 
 /**
- * Release Error Definitions
+ * Delete Error Definitions
 */
-void release_error_definition(java_error_definition* err_def)
+static void delete_error_definitions(java_error_definition* err_def)
 {
-    free(err_def->descriptor);
-    free(err_def->message);
+    free(err_def);
+}
+
+static void init_error_stack(java_error_stack* stack, java_error_stack* amb_parent);
+static void release_error_stack(java_error_stack* stack);
+static bool error_stack_empty(const java_error_stack* stack);
+
+static void init_error_summary(java_error_summary* summary)
+{
+    if (!summary) { return; }
+
+    summary->num_err = 0;
+    summary->num_info = 0;
+    summary->num_warn = 0;
+}
+
+static void release_error_summary(java_error_summary* summary)
+{
+    // so far there is nothing to do...
+}
+
+static void delete_error_summary(java_error_summary* summary)
+{
+    release_error_summary(summary);
+    free(summary);
+}
+
+static void error_summary_diff(java_error_summary* diff, java_error_summary* cache, java_error_summary* current)
+{
+    if (!diff)
+    {
+        return;
+    }
+    else
+    {
+        init_error_summary(diff);
+
+        if (!cache || !current)
+        {
+            diff->num_err = 0;
+            diff->num_warn = 0;
+            diff->num_info = 0;
+        }
+        else
+        {
+            diff->num_err = current->num_err - cache->num_err;
+            diff->num_warn = current->num_warn - cache->num_warn;
+            diff->num_info = current->num_info - cache->num_info;
+        }
+    }
+}
+
+static void error_summary_merge(java_error_summary* dest, const java_error_summary* src)
+{
+    if (!dest || !src) { return; }
+
+    dest->num_err += src->num_err;
+    dest->num_warn += src->num_warn;
+    dest->num_info += src->num_info;
+}
+
+static void error_summary_update(const java_error_definition* def, java_error_summary* summary, java_error_id id)
+{
+    if (!summary) { return; }
+
+    switch (def[id].descriptor & ERR_DEF_MASK_LEVEL)
+    {
+        case JEL_INFORMATION:
+            summary->num_info++;
+            break;
+        case JEL_WARNING:
+            summary->num_warn++;
+            break;
+        case JEL_ERROR:
+            summary->num_err++;
+            break;
+        default:
+            break;
+    }
+}
+
+static java_error_entry* new_error_entry(java_error_entry_type type, java_error_id id)
+{
+    java_error_entry* entry = (java_error_entry*)malloc_assert(sizeof(java_error_entry));
+
+    entry->type = type;
+    entry->id = id;
+    entry->begin = LINE(0, 0);
+    entry->end = LINE(0, 0);
+    entry->msg = NULL;
+    entry->prev = NULL;
+    entry->next = NULL;
+
+    entry->ambiguity.arr = NULL;
+    entry->ambiguity.len = 0;
+    entry->ambiguity.size = 0;
+
+    return entry;
+}
+
+static void delete_error_entry(java_error_entry* entry)
+{
+    if (!entry) { return; }
+
+    for (size_t i = 0; i < entry->ambiguity.len; i++)
+    {
+        release_error_stack(&entry->ambiguity.arr[i]);
+    }
+
+    free(entry->ambiguity.arr);
+    free(entry->msg);
+    free(entry);
+}
+
+/**
+ * resolve an ambiguity entry on stack
+*/
+static bool error_entry_resolve_ambiguity(java_error_entry* entry, size_t idx)
+{
+    if (!entry || entry->type != ERROR_ENTRY_AMBIGUITY || idx >= entry->ambiguity.len)
+    {
+        return false;
+    }
+
+    java_error_stack* target = &entry->ambiguity.arr[idx];
+    java_error_stack* dest = target->amb_parent;
+    java_error_entry* prev = entry->prev;
+    java_error_entry* next = entry->next;
+
+    if (prev)
+    {
+        prev->next = error_stack_empty(target) ? next : target->first;
+    }
+    else
+    {
+        dest->first = target->first;
+    }
+
+    if (next)
+    {
+        next->prev = error_stack_empty(target) ? prev : target->last;
+    }
+    else
+    {
+        dest->last = target->last;
+    }
+
+    error_summary_merge(&dest->summary, &target->summary);
+
+    // for each ambiguity entry in target stack, all ambiguity stack should re-align with new amb_parent
+    for (java_error_entry* p = target->first; p != NULL; p = p->next)
+    {
+        if (p->type == ERROR_ENTRY_AMBIGUITY)
+        {
+            for (size_t i = 0; i < p->ambiguity.len; i++)
+            {
+                p->ambiguity.arr[i].amb_parent = dest->amb_parent;
+            }
+        }
+    }
+
+    // detach stack
+    target->first = NULL;
+    target->last = NULL;
+
+    // delete entry
+    delete_error_entry(entry);
+
+    return true;
+}
+
+static void init_error_stack(java_error_stack* stack, java_error_stack* amb_parent)
+{
+    if (!stack) { return; }
+
+    stack->amb_parent = amb_parent;
+    stack->num_ambiguity = 0;
+    stack->first = NULL;
+    stack->last = NULL;
+
+    init_error_summary(&stack->summary);
+}
+
+static void release_error_stack(java_error_stack* stack)
+{
+    if (!stack) { return; }
+
+    java_error_entry* cur;
+
+    while (true)
+    {
+        cur = stack->first;
+
+        if (!cur) { break; }
+
+        stack->first = cur->next;
+        delete_error_entry(cur);
+    }
+}
+
+static bool error_stack_empty(const java_error_stack* stack)
+{
+    return !stack || stack->first == NULL || stack->last == NULL;
+}
+
+static java_error_entry* error_stack_top(const java_error_stack* stack)
+{
+    return stack ? stack->last : NULL;
+}
+
+static java_error_entry* error_stack_push(java_error_definition* def, java_error_stack* stack, java_error_entry* entry)
+{
+    if (!stack || !entry) { return NULL; }
+
+    if (error_stack_empty(stack))
+    {
+        stack->first = entry;
+    }
+    else
+    {
+        entry->prev = stack->last;
+        stack->last->next = entry;
+    }
+
+    stack->last = entry;
+
+    if (entry->type == ERROR_ENTRY_AMBIGUITY)
+    {
+        stack->num_ambiguity++;
+    }
+    else
+    {
+        error_summary_update(def, &stack->summary, entry->id);
+    }
+
+    return entry;
+}
+
+
+static java_error_stack* error_stack_branch_into_ambiguity(java_error_definition* def, java_error_stack* stack)
+{
+    java_error_entry* entry = error_stack_top(stack);
+
+    if (!entry || entry->type != ERROR_ENTRY_AMBIGUITY)
+    {
+        /**
+         * ambiguity entry itself represents an internal error
+         * because in final stack there should not exist any ambiguous entry
+        */
+        entry = error_stack_push(def, stack, new_error_entry(ERROR_ENTRY_AMBIGUITY, JAVA_E_AMBIGUIOUS_ERROR_ENTRY));
+    }
+
+    // grow
+    if (!entry->ambiguity.arr)
+    {
+        entry->ambiguity.arr = (java_error_stack*)malloc_assert(sizeof(java_error_stack));
+        entry->ambiguity.len = 0;
+        entry->ambiguity.size = 1;
+    }
+    else if (entry->ambiguity.len + 1 > entry->ambiguity.size)
+    {
+        entry->ambiguity.size = find_next_pow2_size(entry->ambiguity.len + 1);
+        entry->ambiguity.arr = (java_error_stack*)
+            realloc_assert(entry->ambiguity.arr, sizeof(java_error_stack) * entry->ambiguity.size);
+    }
+
+    // initialize
+    java_error_stack* s = &entry->ambiguity.arr[entry->ambiguity.len];
+    entry->ambiguity.len++;
+    init_error_stack(s, stack);
+
+    return s;
+}
+
+static void error_stack_get_summary(const java_error_stack* stack, java_error_summary* out);
+
+static void error_stack_get_summary_recursive(const java_error_stack* stack, java_error_summary* out)
+{
+    if (!stack || !out) { return; }
+
+    error_summary_merge(out, &stack->summary);
+
+    for (java_error_entry* entry = stack->first; entry != NULL; entry = entry->next)
+    {
+        if (entry->type == ERROR_ENTRY_AMBIGUITY)
+        {
+            for (size_t i = 0; i < entry->ambiguity.len; i++)
+            {
+                java_error_summary sum;
+                error_stack_get_summary(&entry->ambiguity.arr[i], &sum);
+                error_summary_merge(out, &sum);
+            }
+        }
+    }
+}
+
+static void error_stack_get_summary(const java_error_stack* stack, java_error_summary* out)
+{
+    init_error_summary(out);
+    error_stack_get_summary_recursive(stack, out);
 }
 
 /**
  * Initialize Error Manager
 */
-void init_error_stack(java_error_stack* error, java_error_definition* def)
+void init_error_logger(java_error_logger* logger)
 {
-    error->def = def;
-    error->data = NULL;
-    error->top = NULL;
-    error->num_info = 0;
-    error->num_warn = 0;
-    error->num_err = 0;
+    logger->def = new_error_definitions();
+    logger->current_stream = &logger->main_stream;
+
+    init_error_stack(&logger->main_stream, NULL);
 }
 
 /**
  * Release Error Manager
 */
-void release_error_stack(java_error_stack* error)
+void release_error_logger(java_error_logger* logger)
 {
-    clear_error_stack(error);
+    delete_error_definitions(logger->def);
+    release_error_stack(&logger->main_stream);
 }
 
 /**
  * Clear Error Stack
 */
-void clear_error_stack(java_error_stack* error)
+void clear_error_logger(java_error_logger* logger)
 {
-    java_error_entry* cur = error->data;
+    logger->current_stream = &logger->main_stream;
 
-    while (cur)
-    {
-        error->data = cur->next;
-        free(cur);
-        cur = error->data;
-    }
-
-    error->data = NULL;
-    error->top = NULL;
+    release_error_stack(&logger->main_stream);
+    init_error_stack(&logger->main_stream, NULL);
 }
 
 /**
- * Get error stack state
+ * Logger's ignore condition for specific ID
 */
-java_error_entry* error_stack_top(java_error_stack* error)
+bool error_logger_log_ignore(java_error_logger* logger, java_error_id id)
 {
-    return error->top;
+    return !logger || id == JAVA_E_MAX;
 }
 
 /**
- * Check is stack is empty
-*/
-bool error_stack_empty(java_error_stack* error)
-{
-    return error->data == NULL;
-}
-
-/**
- * Stack rewind to a new top
-*/
-void error_stack_rewind(java_error_stack* error, java_error_entry* new_top)
-{
-    while (error->top != new_top && error_stack_pop(error));
-}
-
-/**
- * Pop stack top element
-*/
-bool error_stack_pop(java_error_stack* error)
-{
-    if (error->top == NULL)
-    {
-        return false;
-    }
-
-    java_error_entry* top = error->top;
-
-    if (top->prev)
-    {
-        top->prev->next = NULL;
-    }
-    else
-    {
-        error->data = NULL;
-    }
-
-    error->top = top->prev;
-    free(top);
-
-    return true;
-}
-
-/**
- * Push an entry to error stack
-*/
-void error_stack_push(java_error_stack* error, java_error_entry* item)
-{
-    if (!item)
-    {
-        return;
-    }
-
-    if (error->data)
-    {
-        error->top->next = item;
-        item->prev = error->top;
-    }
-    else
-    {
-        error->data = item;
-    }
-
-    error->top = item;
-}
-
-/**
- * Merge two error stacks
-*/
-void error_stack_concat(java_error_stack* dest, java_error_stack* src)
-{
-    if (!dest || !src || !src->data)
-    {
-        return;
-    }
-
-    if (dest->data)
-    {
-        dest->top->next = src->data;
-    }
-    else
-    {
-        dest->data = src->data;
-    }
-
-    dest->top = src->top;
-    dest->num_err += src->num_err;
-    dest->num_warn += src->num_warn;
-    dest->num_info += src->num_info;
-
-    // detach
-    src->data = NULL;
-    src->top = NULL;
-}
-
-/**
- * Delete error entry
+ * Log an error, with provided argument list
  *
- * WARNING: make sure the entry is in the list, otherwise it will cause
- * memory leak
+ * error logger will assume provided argument matches the string template,
+ * because it lacks the nature to determine what data is passed to it
+ * (due to the implementation-dependent black box "va_list")
 */
-void error_stack_entry_delete(java_error_stack* error, java_error_entry* entry)
+void error_logger_vslog(java_error_logger* logger, line* begin, line* end, java_error_id id, va_list* arguments)
 {
-    if (entry->prev)
+    if (error_logger_log_ignore(logger, id)) { return; }
+
+    java_error_entry* entry =
+        error_stack_push(logger->def, logger->current_stream, new_error_entry(ERROR_ENTRY_NORMAL, id));
+    const char* format = logger->def[id].message;
+    va_list args;
+    int len;
+
+    // fill line info if applicable
+    if (begin) { line_copy(&entry->begin, begin); }
+    if (end) { line_copy(&entry->end, end); }
+
+    // get target string length
+    va_copy(args, *arguments);
+    len = vsnprintf(NULL, 0, format, args);
+    va_end(args);
+
+    // if length is invalid, there is not much choice left
+    if (len < 0)
     {
-        entry->prev->next = entry->next;
-    }
-    else
-    {
-        error->data = entry->next;
+        fprintf(stderr, "Error logger failed to construct error message with ID %d.\n", id);
+        return;
     }
 
-    if (entry->next)
-    {
-        entry->next->prev = entry->prev;
-    }
-    else
-    {
-        error->top = entry->prev;
-    }
+    entry->msg = (char*)malloc_assert(sizeof(char) * (len + 1));
 
-    free(entry);
-}
-
-/**
- * Error Entry Generator
-*/
-static java_error_entry* error_new_entry(java_error_id id, size_t ln, size_t col)
-{
-    java_error_entry* entry = (java_error_entry*)malloc_assert(sizeof(java_error_entry));
-
-    entry->id = id;
-    entry->ln = ln;
-    entry->col = col;
-    entry->prev = NULL;
-    entry->next = NULL;
-
-    return entry;
+    // generate error message
+    va_copy(args, *arguments);
+    vsprintf(entry->msg, format, args);
+    va_end(args);
 }
 
 /**
  * Log an error
+ *
+ * this is a warpper with variadic length arguments
+ *
+ * all customized wrapper can use this as a template
 */
-void error_log(java_error_stack* error, java_error_id id, size_t ln, size_t col)
+void error_logger_log(java_error_logger* logger, line* begin, line* end, java_error_id id, ...)
 {
-    if (!error || id == JAVA_E_MAX)
+    va_list args;
+
+    va_start(args, id);
+    error_logger_vslog(logger, begin, end, id, &args);
+    va_end(args);
+}
+
+/**
+ * Begin an ambiguity stack
+ *
+ * if current stack top is ambiguity entry, it will use it,
+ * otherwise it will push one
+ *
+ * then it will allocate one stack and enter that context
+ *
+*/
+void error_logger_ambiguity_begin(java_error_logger* logger)
+{
+    logger->current_stream = error_stack_branch_into_ambiguity(logger->def, logger->current_stream);
+}
+
+/**
+ * Finish current ambiguity stack
+ *
+ * it will treat current stream as an ambiguity stack, and return current
+ * stream back to the one that holds it
+*/
+void error_logger_ambiguity_end(java_error_logger* logger)
+{
+    if (logger->current_stream->amb_parent)
     {
-        return;
+        logger->current_stream = logger->current_stream->amb_parent;
     }
-
-    error_stack_push(error, error_new_entry(id, ln, col));
-
-    switch (error->def->descriptor[id] & ERR_DEF_MASK_LEVEL)
+    else
     {
-        case JEL_INFORMATION:
-            error->num_info++;
-            break;
-        case JEL_WARNING:
-            error->num_warn++;
-            break;
-        case JEL_ERROR:
-            error->num_err++;
-            break;
-        default:
-            break;
+        logger->current_stream = &logger->main_stream;
     }
 }
 
 /**
- * count specific level
+ * Resolve an ambiguity entry
 */
-size_t error_count(java_error_stack* error, error_descriptor error_level)
+bool error_logger_ambiguity_resolve(java_error_logger* logger, java_error_entry* entry, size_t idx)
 {
-    switch (error_level)
-    {
-        case JEL_INFORMATION:
-            return error->num_info;
-        case JEL_WARNING:
-            return error->num_warn;
-        case JEL_ERROR:
-            return error->num_err;
-        default:
-            return 0;
-    }
+    return error_entry_resolve_ambiguity(entry, idx);
+}
+
+/**
+ * count ambiguity entry on main stack
+ *
+*/
+size_t error_logger_count_main_ambiguity(java_error_logger* logger)
+{
+    return logger->main_stream.num_ambiguity;
+}
+
+/**
+ * count ambiguity entry on current stack
+ *
+*/
+size_t error_logger_count_current_ambiguity(java_error_logger* logger)
+{
+    return logger->current_stream ? logger->current_stream->num_ambiguity : 0;
+}
+
+/**
+ * get stack top of main stream
+*/
+java_error_entry* error_logger_get_main_top(const java_error_logger* logger)
+{
+    return error_stack_top(&logger->main_stream);
+}
+
+/**
+ * get stack top of current stream
+*/
+java_error_entry* error_logger_get_current_top(const java_error_logger* logger)
+{
+    return error_stack_top(logger->current_stream);
+}
+
+/**
+ * Get summary of main stack
+ *
+ * this routine executes recursive counting process and might be expensive
+*/
+void error_logger_count_main_summary(const java_error_logger* logger, java_error_summary* out)
+{
+    error_stack_get_summary(&logger->main_stream, out);
+}
+
+void error_logger_count_current_summary(const java_error_logger* logger, java_error_summary* out)
+{
+    error_stack_get_summary(logger->current_stream, out);
+}
+
+/**
+ * Check if main stack has error
+ *
+ * this routine executes recursive counting process and might be expensive
+*/
+bool error_logger_if_main_stack_no_error(const java_error_logger* logger)
+{
+    java_error_summary sum;
+    error_stack_get_summary(&logger->main_stream, &sum);
+
+    return sum.num_err == 0;
+}
+
+/**
+ * Check if current stack has error
+ *
+ * this routine executes recursive counting process and might be expensive
+*/
+bool error_logger_if_current_stack_no_error(const java_error_logger* logger)
+{
+    java_error_summary sum;
+    error_stack_get_summary(logger->current_stream, &sum);
+
+    return sum.num_err == 0;
+}
+
+/**
+ * get context string
+*/
+char* error_logger_get_context_string(const java_error_logger* logger, java_error_id id)
+{
+    char* ctx = logger->def[id].context;
+    return ctx ? ctx : STR_NULL;
 }

--- a/error.h
+++ b/error.h
@@ -5,7 +5,7 @@
 #include "types.h"
 
 /**
- * Error Definition
+ * Error Type Descriptor
  *
  * 0000 0000
  * ____
@@ -17,13 +17,13 @@
  * both parts are described as integer index value,
  * numbered from 0 to 15 (0xF) consecutively
 */
-typedef unsigned char error_descriptor;
+typedef uint8_t error_type;
 
 /**
  * Definition Mask
 */
-#define ERR_DEF_MASK_LEVEL ((error_descriptor)(0xF0))
-#define ERR_DEF_MASK_SCOPE ((error_descriptor)(0x0F))
+#define ERR_DEF_MASK_LEVEL ((error_type)(0xF0))
+#define ERR_DEF_MASK_SCOPE ((error_type)(0x0F))
 
 /**
  * Error Type
@@ -31,9 +31,9 @@ typedef unsigned char error_descriptor;
  * index value
 */
 #define JEL_UNDEFINED 0
-#define JEL_INFORMATION ((error_descriptor)(0x10))
-#define JEL_WARNING ((error_descriptor)(0x20))
-#define JEL_ERROR ((error_descriptor)(0x30))
+#define JEL_INFORMATION ((error_type)(0x10))
+#define JEL_WARNING ((error_type)(0x20))
+#define JEL_ERROR ((error_type)(0x30))
 
 /**
  * Error Scope
@@ -50,23 +50,23 @@ typedef unsigned char error_descriptor;
  * BUILD: error from building process
 */
 #define JES_UNDEFINED 0
-#define JES_INTERNAL ((error_descriptor)(0x01))
-#define JES_RUNTIME ((error_descriptor)(0x02))
-#define JES_LEXICAL ((error_descriptor)(0x03))
-#define JES_SYNTAX ((error_descriptor)(0x04))
-#define JES_CONTEXT ((error_descriptor)(0x05))
-#define JES_OPTIMIZATION ((error_descriptor)(0x06))
-#define JES_LINKER ((error_descriptor)(0x07))
-#define JES_BUILD ((error_descriptor)(0x08))
+#define JES_INTERNAL ((error_type)(0x01))
+#define JES_RUNTIME ((error_type)(0x02))
+#define JES_LEXICAL ((error_type)(0x03))
+#define JES_SYNTAX ((error_type)(0x04))
+#define JES_CONTEXT ((error_type)(0x05))
+#define JES_OPTIMIZATION ((error_type)(0x06))
+#define JES_LINKER ((error_type)(0x07))
+#define JES_BUILD ((error_type)(0x08))
 
 /**
  * Definition helpers
 */
 #define DEFINE_ERROR(l, s) ((l) | (s))
-#define JEL_TO_INDEX(l) (((error_descriptor)(l)) >> 4)
+#define JEL_TO_INDEX(l) (((error_type)(l)) >> 4)
 #define DEFINE_RESERVED_ERROR 0
-#define DEFINE_SYNTAX_ERROR ((error_descriptor)(0x34))
-#define DEFINE_CONTEXT_ERROR ((error_descriptor)(0x35))
+#define DEFINE_SYNTAX_ERROR ((error_type)(0x34))
+#define DEFINE_CONTEXT_ERROR ((error_type)(0x35))
 
 /**
  * Error Message ID
@@ -78,6 +78,15 @@ typedef unsigned char error_descriptor;
 typedef enum
 {
     JAVA_E_RESERVED = 0,
+    JAVA_E_NO_DIGIT,
+    JAVA_E_ILLEGAL_CHARACTER,
+    JAVA_E_CHARACTER_LITERAL_ENCLOSE,
+    JAVA_E_STRING_LITERAL_ENCLOSE,
+    JAVA_E_MULTILINE_COMMENT_ENCLOSE,
+    JAVA_E_AMBIGUIOUS_ERROR_ENTRY,
+    JAVA_E_PASER_SWAP_FAILED,
+    JAVA_E_PASER_DELETE_FAILED,
+    JAVA_E_AMBIGUITY_DIVERGE,
     JAVA_E_FILE_NO_PATH,
     JAVA_E_FILE_OPEN_FAILED,
     JAVA_E_FILE_SIZE_NOT_MATCH,
@@ -88,17 +97,58 @@ typedef enum
     JAVA_E_IMPORT_NO_SEMICOLON,
     JAVA_E_IMPORT_AMBIGUOUS,
     JAVA_E_IMPORT_DUPLICATE,
+    JAVA_E_TOP_LEVEL,
     JAVA_E_CLASS_NO_NAME,
     JAVA_E_CLASS_NO_BODY,
     JAVA_E_CLASS_NAME_DUPLICATE,
     JAVA_E_CLASS_BODY_ENCLOSE,
+    java_E_CLASS_ENTENDS_NO_NAME,
+    java_E_CLASS_IMPLEMENTS_NO_NAME,
+    JAVA_E_INTERFACE_NO_NAME,
+    JAVA_E_INTERFACE_NO_BODY,
+    java_E_INTERFACE_ENTENDS_NO_NAME,
+    JAVA_E_INTERFACE_BODY_ENCLOSE,
     JAVA_E_MEMBER_VAR_DUPLICATE,
     JAVA_E_MEMBER_VAR_DIM_AMBIGUOUS,
     JAVA_E_MEMBER_VAR_DIM_DUPLICATE,
     JAVA_E_MEMBER_VAR_NO_SEMICOLON,
+    JAVA_E_MEMBER_METHOD_NO_SEMICOLON,
     JAVA_E_MEMBER_NO_TYPE,
     JAVA_E_MEMBER_NO_NAME,
     JAVA_E_MEMBER_AMBIGUOUS,
+    JAVA_E_STATIC_INITIALIZER_NO_BODY,
+    JAVA_E_BLOCK_ENCLOSE,
+    JAVA_E_STATEMENT_UNRECOGNIZED,
+    JAVA_E_STATEMENT_SWITCH,
+    JAVA_E_STATEMENT_DO,
+    JAVA_E_STATEMENT_BREAK,
+    JAVA_E_STATEMENT_CONTINUE,
+    JAVA_E_STATEMENT_RETURN,
+    JAVA_E_STATEMENT_SYNCHRONIZED,
+    JAVA_E_STATEMENT_THROW,
+    JAVA_E_STATEMENT_TRY,
+    JAVA_E_STATEMENT_IF,
+    JAVA_E_STATEMENT_ELSE,
+    JAVA_E_STATEMENT_WHILE,
+    JAVA_E_STATEMENT_FOR,
+    JAVA_E_STATEMENT_FOR_INITIALIZER_NO_SEMICOLON,
+    JAVA_E_STATEMENT_FOR_CONDITION_NO_SEMICOLON,
+    JAVA_E_STATEMENT_LABEL,
+    JAVA_E_STATEMENT_CATCH,
+    JAVA_E_STATEMENT_FINALLY,
+    JAVA_E_STATEMENT_SWITCH_LABEL,
+    JAVA_E_CONSTRUCTOR,
+    JAVA_E_CONSTRUCTOR_INVOKE,
+    JAVA_E_METHOD_DECLARATION,
+    JAVA_E_METHOD_INVOKE,
+    JAVA_E_FORMAL_PARAMETER,
+    JAVA_E_THROWS_NO_TYPE,
+    JAVA_E_NO_ARGUMENT,
+    JAVA_E_ARRAY_INITIALIZER,
+    JAVA_E_ARRAY_CREATION,
+    JAVA_E_ARRAY_ACCESS,
+    JAVA_E_OBJECT_CREATION,
+    JAVA_E_INSTANCE_CREATION,
     JAVA_E_EXPRESSION_NO_OPERAND,
     JAVA_E_EXPRESSION_TOO_MANY_OPERAND,
     JAVA_E_EXPRESSION_INCOMPLETE_TERNARY,
@@ -138,36 +188,6 @@ typedef enum
     JAVA_E_EXPRESSION_PARENTHESIS,
     JAVA_E_TYPE_NO_ARR_ENCLOSE,
 
-    /**
-     * Ambiguity Error Flags
-     *
-     * INTERNAL:
-     * the following are not errors
-     * they are placeholders for
-     * error parser
-     *
-     * JAVA_E_AMBIGUITY_START
-     * Err |
-     * Err |---JAVA_E_AMBIGUITY_PATH_1
-     * ... |
-     * JAVA_E_AMBIGUITY_SEPARATOR
-     * Err |
-     * Err |---JAVA_E_AMBIGUITY_PATH_2
-     * ... |
-     * JAVA_E_AMBIGUITY_END
-     *
-     * If ambiguity is resolved, the ID
-     * JAVA_E_AMBIGUITY_START will be changed
-     * into JAVA_E_AMBIGUITY_PATH_1 or
-     * JAVA_E_AMBIGUITY_PATH_2 accordingly
-    */
-
-    JAVA_E_AMBIGUITY_START,
-    JAVA_E_AMBIGUITY_PATH_1,
-    JAVA_E_AMBIGUITY_PATH_2,
-    JAVA_E_AMBIGUITY_SEPARATOR,
-    JAVA_E_AMBIGUITY_END,
-
     JAVA_E_MAX,
 } java_error_id;
 
@@ -177,15 +197,43 @@ typedef enum
  * ONLYSTATIC: this instance contains static data
  * shared across all compile tasks
  *
- * use java_error_stack for task-specific data
+ * use java_error_logger for task-specific data
 */
 typedef struct
 {
-    /* ID-to-descriptor mapping */
-    error_descriptor* descriptor;
-    /* ID-to-message mapping */
-    char** message;
+    // type of each error ID
+    error_type descriptor;
+    // (parser) context name
+    char* context;
+    // message text of each error ID
+    char* message;
 } java_error_definition;
+
+/**
+ * Error Summary
+*/
+typedef struct
+{
+    // number of info
+    size_t num_info;
+    // number of warnings
+    size_t num_warn;
+    // number of errors
+    size_t num_err;
+} java_error_summary;
+
+/**
+ * Error Entry Type
+ *
+ * ERROR_ENTRY_AMBIGUITY does not contain
+ * actual error info; instead, it manages an array
+ * of error_stack for every pathway of ambguity
+*/
+typedef enum
+{
+    ERROR_ENTRY_NORMAL,
+    ERROR_ENTRY_AMBIGUITY,
+} java_error_entry_type;
 
 /**
  * Error Entry
@@ -194,51 +242,74 @@ typedef struct
 */
 typedef struct _java_error_entry
 {
+    java_error_entry_type type;
     java_error_id id;
-    size_t ln;
-    size_t col;
+    line begin;
+    line end;
+    char* msg;
 
     struct _java_error_entry* prev;
     struct _java_error_entry* next;
+
+    struct
+    {
+        struct _java_error_stack* arr;
+        size_t len;
+        size_t size;
+    } ambiguity;
 } java_error_entry;
+
+/**
+ * Error Stack
+*/
+typedef struct _java_error_stack
+{
+    // if this stack belong to an ERROR_ENTRY_AMBIGUITY, this field will be set
+    struct _java_error_stack* amb_parent;
+    // summary, excluding ambiguity entries
+    java_error_summary summary;
+    // number of ambiguity entry
+    size_t num_ambiguity;
+
+    java_error_entry* first;
+    java_error_entry* last;
+} java_error_stack;
 
 /**
  * Error Data Instance
  *
  * Definition is indexed by java_error_id
+ * summary will stop counting at first entry with divergence
 */
 typedef struct
 {
-    /* error definitions */
+    // error definitions
     java_error_definition* def;
-    /* error stack */
-    java_error_entry* data;
-    /* error stack top */
-    java_error_entry* top;
-    /* number of info */
-    size_t num_info;
-    /* number of warnings */
-    size_t num_warn;
-    /* number of errors */
-    size_t num_err;
-} java_error_stack;
 
-void init_error_definition(java_error_definition* err_def);
-void release_error_definition(java_error_definition* err_def);
+    // main error stack
+    java_error_stack main_stream;
+    // current error stream
+    java_error_stack* current_stream;
+} java_error_logger;
 
-void init_error_stack(java_error_stack* error, java_error_definition* def);
-void release_error_stack(java_error_stack* error);
-void clear_error_stack(java_error_stack* error);
+void init_error_logger(java_error_logger* logger);
+void release_error_logger(java_error_logger* logger);
+void clear_error_logger(java_error_logger* logger);
 
-java_error_entry* error_stack_top(java_error_stack* error);
-bool error_stack_empty(java_error_stack* error);
-void error_stack_rewind(java_error_stack* error, java_error_entry* new_top);
-bool error_stack_pop(java_error_stack* error);
-void error_stack_push(java_error_stack* error, java_error_entry* item);
-void error_stack_concat(java_error_stack* dest, java_error_stack* src);
-void error_stack_entry_delete(java_error_stack* error, java_error_entry* entry);
-
-void error_log(java_error_stack* error, java_error_id id, size_t ln, size_t col);
-size_t error_count(java_error_stack* error, error_descriptor error_level);
+bool error_logger_log_ignore(java_error_logger* logger, java_error_id id);
+void error_logger_vslog(java_error_logger* logger, line* begin, line* end, java_error_id id, va_list* arguments);
+void error_logger_log(java_error_logger* logger, line* begin, line* end, java_error_id id, ...);
+void error_logger_ambiguity_begin(java_error_logger* logger);
+void error_logger_ambiguity_end(java_error_logger* logger);
+bool error_logger_ambiguity_resolve(java_error_logger* logger, java_error_entry* entry, size_t idx);
+size_t error_logger_count_main_ambiguity(java_error_logger* logger);
+size_t error_logger_count_current_ambiguity(java_error_logger* logger);
+java_error_entry* error_logger_get_main_top(const java_error_logger* logger);
+java_error_entry* error_logger_get_current_top(const java_error_logger* logger);
+void error_logger_count_main_summary(const java_error_logger* logger, java_error_summary* out);
+void error_logger_count_current_summary(const java_error_logger* logger, java_error_summary* out);
+bool error_logger_if_main_stack_no_error(const java_error_logger* logger);
+bool error_logger_if_current_stack_no_error(const java_error_logger* logger);
+char* error_logger_get_context_string(const java_error_logger* logger, java_error_id id);
 
 #endif

--- a/expression.h
+++ b/expression.h
@@ -12,7 +12,7 @@
 #include "types.h"
 #include "langspec.h"
 #include "tree.h"
-#include "token.h"
+#include "lexer.h"
 
 /**
  * Operator Info

--- a/file.h
+++ b/file.h
@@ -24,14 +24,15 @@ typedef struct _file_buffer
     /* buffer cursor of current read position */
     byte* cur;
     /* error logger */
-    java_error_stack* error;
+    java_error_logger* logger;
 } file_buffer;
 
-void init_file_buffer(file_buffer* buffer, java_error_stack* error_logger);
+void init_file_buffer(file_buffer* buffer, java_error_logger* error_logger);
 void release_file_buffer(file_buffer* buffer);
 bool load_source_file(file_buffer* buffer, const char* name);
 
 bool is_eof(file_buffer* buffer);
+void buffer_error(file_buffer* buffer, java_error_id id, ...);
 bool buffer_ptr_safe_move(file_buffer* buffer);
 byte buffer_peek(file_buffer* buffer, int offset);
 size_t buffer_count(const byte* from, const byte* to);

--- a/ir.c
+++ b/ir.c
@@ -23,13 +23,13 @@ static void top_level_lookup_deleter(char* k, global_top_level* v)
 /**
  * initialize semantic analysis
 */
-void init_ir(java_ir* ir, java_expression* expression, java_error_stack* error)
+void init_ir(java_ir* ir, java_expression* expression, java_error_logger* logger)
 {
     ir->working_top_level = NULL;
     ir->scope_stack_top = NULL;
     ir->arch = NULL;
     ir->expression = expression;
-    ir->error = error;
+    ir->logger = logger;
     ir->scope_workers = NULL;
     ir->statement_contexts = NULL;
 
@@ -60,7 +60,7 @@ void release_ir(java_ir* ir)
 */
 void ir_error(java_ir* ir, java_error_id id)
 {
-    error_log(ir->error, id, 0, 0);
+    error_logger_log(ir->logger, 0, 0, id);
 }
 
 /**

--- a/ir.h
+++ b/ir.h
@@ -582,7 +582,7 @@ typedef struct
     // expression-related info
     java_expression* expression;
     // error data
-    java_error_stack* error;
+    java_error_logger* logger;
 } java_ir;
 
 char* t2s(java_token* token);
@@ -751,7 +751,7 @@ void walk_interface(java_ir* ir, global_top_level* interface);
 
 char primitive_type_to_jil_type(java_lexeme_type p);
 
-void init_ir(java_ir* ir, java_expression* expression, java_error_stack* error);
+void init_ir(java_ir* ir, java_expression* expression, java_error_logger* logger);
 void release_ir(java_ir* ir);
 void contextualize(java_ir* ir, architecture* arch, tree_node* compilation_unit);
 void ir_error(java_ir* ir, java_error_id id);

--- a/ir.h
+++ b/ir.h
@@ -4,7 +4,7 @@
 
 #include "types.h"
 #include "hash-table.h"
-#include "token.h"
+#include "lexer.h"
 #include "expression.h"
 #include "tree.h"
 #include "error.h"

--- a/lexer.c
+++ b/lexer.c
@@ -1,4 +1,4 @@
-#include "token.h"
+#include "lexer.h"
 
 static bool consume_char_default(java_lexer* lexer)
 {

--- a/lexer.h
+++ b/lexer.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __COMPILER_TOKEN_H__
-#define __COMPILER_TOKEN_H__
+#ifndef __COMPILER_LEXER_H__
+#define __COMPILER_LEXER_H__
 
 #include "types.h"
 #include "langspec.h"

--- a/main.c
+++ b/main.c
@@ -77,8 +77,9 @@ int main(int argc, char* argv[])
         }
 
         // debug_file_buffer(&compiler.reader);
-        // debug_tokenize(&compiler.reader, &compiler.rw_lookup_table);
+        // debug_tokenize(&compiler.reader, &compiler.rw_lookup_table, &compiler->logger);
         compiler_error_format_print(&compiler);
+        debug_print_error_logger(&compiler.logger);
     }
 
     release_compiler(&compiler);

--- a/node.h
+++ b/node.h
@@ -7,8 +7,6 @@
  *
  * the type will help node determine which type
  * the data is binded to the tree node
- *
- * the value also serves as index to access serialized parser function name
 */
 typedef enum
 {

--- a/node.h
+++ b/node.h
@@ -7,10 +7,12 @@
  *
  * the type will help node determine which type
  * the data is binded to the tree node
+ *
+ * the value also serves as index to access serialized parser function name
 */
 typedef enum
 {
-    JNT_UNIT,
+    JNT_UNIT = 0,
     JNT_NAME_UNIT,
     JNT_NAME,
     JNT_CLASS_TYPE_UNIT,

--- a/number.h
+++ b/number.h
@@ -2,7 +2,7 @@
 #ifndef __COMPILER_NUMBER_H__
 #define __COMPILER_NUMBER_H__
 
-#include "token.h"
+#include "lexer.h"
 #include "types.h"
 
 /**

--- a/parser-util.c
+++ b/parser-util.c
@@ -20,12 +20,12 @@ java_token* token_peek(java_parser* parser, size_t idx)
     // buffer it if not yet available
     for (size_t i = parser->num_token_available; i <= idx; i++)
     {
-        get_next_token(parser->tokens + i, parser->buffer, parser->reserved_words);
+        lexer_next_token(parser->lexer, parser->tokens + i);
 
         // discard comments
         while (parser->tokens[i].class == JT_COMMENT)
         {
-            get_next_token(parser->tokens + i, parser->buffer, parser->reserved_words);
+            lexer_next_token(parser->lexer, parser->tokens + i);
         }
     }
 
@@ -137,10 +137,16 @@ bool is_lexeme_literal(java_lexeme_type type)
 /**
  * Error Logger
  *
- * TODO: we need a clever way to get line info from java_parser instance
+ * TODO: what line info do we need here?
+ * TODO: need line_end info for future snapshot info creation
 */
-void parser_error(java_parser* parser, java_error_id id)
+void parser_error(java_parser* parser, java_error_id id, ...)
 {
-    error_log(parser->error, id, 0, 0);
+    va_list args;
+
+    va_start(args, id);
+    error_logger_vslog(parser->logger, &parser->lexer->ln_cur, NULL, id, &args);
+    va_end(args);
+
     parser_recovery_dispatch(parser, id);
 }

--- a/parser.h
+++ b/parser.h
@@ -10,6 +10,9 @@
 #include "expression.h"
 #include "error.h"
 
+#define parser_error_missing_token(parser, id, token_name) \
+    parser_error(parser, id, token_name, error_logger_get_context_string(parser->logger, id))
+
 /**
  * Token Peek Index
  *
@@ -29,12 +32,14 @@
 */
 typedef struct _java_parser
 {
+    /* copy flag */
+    bool is_copy;
     /* 4 look-ahead tokens */
     java_token tokens[4];
     /* num look-ahead available */
     size_t num_token_available;
-    /* file buffer */
-    file_buffer* buffer;
+    /* lexer */
+    java_lexer* lexer;
     /* language spec symbol table*/
     hash_table* reserved_words;
     /* AST */
@@ -42,19 +47,19 @@ typedef struct _java_parser
     /* expression definition */
     java_expression* expression;
     /* error data */
-    java_error_stack* error;
+    java_error_logger* logger;
 } java_parser;
 
 void init_parser(
     java_parser* parser,
-    file_buffer* buffer,
+    java_lexer* lexer,
     hash_table* rw,
     java_expression* expr,
-    java_error_stack* err
+    java_error_logger* logger
 );
 void copy_parser(java_parser* from, java_parser* to);
 void mutate_parser(java_parser* parser, java_parser* copy);
-void release_parser(java_parser* parser, bool is_copy);
+void release_parser(java_parser* parser);
 
 void parse(java_parser* parser);
 
@@ -78,7 +83,7 @@ bool parser_trigger_expression(java_parser* parser, size_t peek_from);
 bool parser_trigger_primary(java_parser* parser, size_t peek_from);
 bool parser_trigger_statement(java_parser* parser, size_t peek_from);
 
-void parser_error(java_parser* parser, java_error_id id);
+void parser_error(java_parser* parser, java_error_id id, ...);
 void parser_recovery_dispatch(java_parser* parser, java_error_id id);
 
 #endif

--- a/parser.h
+++ b/parser.h
@@ -4,7 +4,7 @@
 
 #include "types.h"
 #include "hash-table.h"
-#include "token.h"
+#include "lexer.h"
 #include "file.h"
 #include "symtbl.h"
 #include "expression.h"

--- a/tree.h
+++ b/tree.h
@@ -4,7 +4,7 @@
 
 #include "types.h"
 #include "langspec.h"
-#include "token.h"
+#include "lexer.h"
 #include "node.h"
 #include "error.h"
 

--- a/tree.h
+++ b/tree.h
@@ -93,7 +93,7 @@ typedef struct
 */
 typedef struct
 {
-    // pointer to JAVA_E_AMBIGUITY_START
+    // pointer to ERROR_ENTRY_AMBIGUITY
     java_error_entry* error;
 } node_data_ambiguity;
 

--- a/types.c
+++ b/types.c
@@ -1,6 +1,18 @@
 #include "types.h"
 
 /**
+ * copy line info data
+*/
+void line_copy(line* dest, line* src)
+{
+    ASSERT_ALLOCATION(dest);
+    ASSERT_ALLOCATION(src);
+
+    dest->ln = src->ln;
+    dest->col = src->col;
+}
+
+/**
  * a verbose wrapper of allocation
 */
 void* malloc_assert(size_t sz)

--- a/types.h
+++ b/types.h
@@ -28,16 +28,29 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdarg.h>
 
 #define ASSERT_ALLOCATION(ptr) assert((ptr) != NULL)
 #define ARRAY_SIZE(arr) (sizeof (arr) / sizeof ((arr)[0]))
 #define ALLOCATE(type, name) type* name = (type*)malloc_assert(sizeof(type))
+#define LINE(l, c) (line){ .ln = l, .col = c }
+#define VALID_LINE(l) ((l).ln > 0 && (l).col > 0)
 
 typedef unsigned char byte;
 typedef unsigned char bbit_flag;
 typedef unsigned int ibit_flag;
 typedef unsigned long int lbit_flag;
 
+/**
+ * line info
+*/
+typedef struct
+{
+    size_t ln;
+    size_t col;
+} line;
+
+void line_copy(line* dest, line* src);
 void* malloc_assert(size_t sz);
 void* realloc_assert(void* p, size_t sz);
 char* strmcpy_assert(const char* source);


### PR DESCRIPTION
This PR includes major updates for error logger component, with other architectual refactor.

1. New high-level component `java_lexer`, which encapsulates lexer states (line info) as well as `file_buffer` instance
2. New error logger instance `error_logger` on high-level using singleton pattern: `compiler` will spawn one logger instance and all other components will use only this logger
3. New error stack design: each entry on stack now has the capability to contain a list of error stacks to represents that this entry contains ambiguity. This recursives structure allows error logger to be used more easily through singlton pattern
4. `JAVA_E_AMBIGUITY_*` are deprecated because new error logger no longer depends on them
5. Registered all errors from `file_buffer`, `java_lexer`, and `java_parser`
6. New error logging instance: `error_logger_log` and `error_logger_vslog`, so that the logger allows variadic input arguments. Each component could create wrapper further to make the use of the instance with other side effects