### PR TITLE
Index ID For CFG Data

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -43,7 +43,7 @@ void debug_report(compiler* compiler)
         sizeof(java_expression) +
         sizeof(java_operator) * OPID_MAX +
         sizeof(operator_id) * JLT_MAX +
-        sizeof(operation) * OPID_MAX +
+        sizeof(irop) * OPID_MAX +
         sizeof(size_t) * OPID_MAX
     );
     printf("Error static data size: %zd bytes\n",

--- a/debug.h
+++ b/debug.h
@@ -24,7 +24,7 @@ void debug_print_number_type(java_number_type number);
 void debug_print_token_content(java_token* token);
 void debug_print_modifier_bit_flag(lbit_flag modifiers);
 void debug_print_ast_node(java_parser* parser, tree_node* node);
-void debug_print_irop(operation irop);
+void debug_print_irop(irop op);
 void debug_print_cfg_node_type(block_type type);
 void debug_print_reference(reference* r);
 void debug_print_instructions(instruction* inst, size_t* cnt, size_t depth);

--- a/expression.c
+++ b/expression.c
@@ -12,7 +12,7 @@ void init_expression(java_expression* expression)
 
     expression->definition = (java_operator*)malloc_assert(sizeof(java_operator) * OPID_MAX);
     expression->op_map = (operator_id*)malloc_assert(map_size);
-    expression->ir_map = (operation*)malloc_assert(sizeof(operation) * OPID_MAX);
+    expression->ir_map = (irop*)malloc_assert(sizeof(irop) * OPID_MAX);
     expression->opid_operand_count = (size_t*)malloc_assert(sizeof(size_t) * OPID_MAX);
 
     // set default because OPID_UNDEFINED = 0
@@ -296,7 +296,7 @@ operator_id expr_tid2opid(const java_expression* expression, java_lexeme_type ti
 /**
  * map OPID to IROP
 */
-operation expr_opid2irop(const java_expression* expression, operator_id opid)
+irop expr_opid2irop(const java_expression* expression, operator_id opid)
 {
     return expression->ir_map[opid];
 }

--- a/expression.h
+++ b/expression.h
@@ -69,11 +69,11 @@ typedef unsigned short java_operator;
 #define OP(a, p, t) (OP_ASSOC(a) | OP_PRECD(p) | OP_TOKEN(t))
 
 /**
- * IR OP CODE
+ * IR High-Level OP Code
  *
- * every operation has unique identifier, despite what form it has
+ * every irop has unique identifier, despite what form it has
  *
- * The following operator id does not have specific operation:
+ * The following operator id does not have specific irop:
  * 1. composite assignment operators will not be modelled here because it is
  *    implicitly supported by the assignment form
  *
@@ -204,7 +204,7 @@ typedef enum
     IROP_BOOL,
 
     IROP_MAX,
-} operation;
+} irop;
 
 /**
  * Java Expression Definition
@@ -222,7 +222,7 @@ typedef struct
     /* token-to-operator map */
     operator_id* op_map;
     /* static map from OPID to IROP */
-    operation* ir_map;
+    irop* ir_map;
     /* #operand needed for each IROP */
     size_t* opid_operand_count;
 } java_expression;
@@ -233,7 +233,7 @@ void release_expression(java_expression* expression);
 tree_node* expr_opid2node(const operator_id opid);
 java_operator expr_opid2def(const java_expression* expression, operator_id opid);
 operator_id expr_tid2opid(const java_expression* expression, java_lexeme_type tid);
-operation expr_opid2irop(const java_expression* expression, operator_id opid);
+irop expr_opid2irop(const java_expression* expression, operator_id opid);
 size_t expr_opid_operand_count(const java_expression* expression, operator_id opid);
 
 /**

--- a/ir-scope.c
+++ b/ir-scope.c
@@ -126,6 +126,7 @@ hash_table* lookup_working_scope(java_ir* ir)
 void lookup_top_level_begin(java_ir* ir, global_top_level* desc)
 {
     ir->working_top_level = desc;
+    ir->walk_state.num_member_variable = 0;
 }
 
 /**
@@ -191,7 +192,7 @@ definition* new_definition(definition_type type)
     {
         case DEFINITION_VARIABLE:
             v->variable = (definition_variable*)malloc_assert(sizeof(definition_variable));
-            v->variable->is_class_member = false;
+            v->variable->kind = VARIABLE_KIND_MAX;
             v->variable->modifier = JLT_UNDEFINED;
             __init_type_name(&v->variable->type);
             break;


### PR DESCRIPTION
Added index ID for following CFG data:
1. `definition`
   * member variables have index starts from 0 per top level
   * local variables (including method parameters) have index starts from 0 per method/constructor
2. `instruction`: instructions have index starts from 0 per CFG
3. `basic_block`: blocks have index starts from 0 per CFG

Other work:
* All global counters required above are managed by `ir_walk_state` on `java_ir` level.
* Change high-level IR opcode from `operation` to `irop`
* Implemented `variable_kind` to replace `is_member` paradigm: new "kind" will describe variable definition in detail: member, local, or parameter