### PR TITLE
Deprecate IROP_INIT

### DIFF
--- a/debug-print.c
+++ b/debug-print.c
@@ -1063,9 +1063,6 @@ void debug_print_irop(irop op)
         case IROP_LMD:
             printf("IROP_LMD");
             break;
-        case IROP_INIT:
-            printf("IROP_INIT");
-            break;
         case IROP_JMP:
             printf("IROP_JMP");
             break;
@@ -1439,7 +1436,7 @@ void debug_print_definition(definition* v, size_t depth)
             printf("\n");
             break;
         case DEFINITION_NULL:
-            printf("null\n");
+            printf("null object\n");
             break;
         default:
             // no-op

--- a/expression.h
+++ b/expression.h
@@ -122,7 +122,6 @@ typedef unsigned short java_operator;
  * IROP_TC      ternary: condition part (a ? TB)
  * IROP_TB,     ternary: branch part (c : d)
  * IROP_LMD     lambda
- * IROP_INIT    default initialization of a variable
  * IROP_JMP     jump (triggers EDGE_JUMP)
  * IROP_RET     return
  * IROP_TEST    test-and-jump
@@ -194,7 +193,6 @@ typedef enum
 
     /* IR-specific */
 
-    IROP_INIT,
     IROP_JMP,
     IROP_RET,
     IROP_TEST,

--- a/ir-walk.c
+++ b/ir-walk.c
@@ -996,11 +996,13 @@ static void __execute_variable_declaration(java_ir* ir, tree_node* stmt)
         }
         else
         {
+            operand = new_reference(IR_ASN_REF_LITERAL, def_li_null(ir));
+
             /**
              * otherwise we insert a dummy code, indicate that
              * the variable is defined here and some initialization required
             */
-            execute_irop_instruction(ir, TSW(ir), IROP_INIT, &lvalue, NULL, NULL);
+            execute_irop_instruction(ir, TSW(ir), IROP_ASN, &lvalue, &operand, NULL);
         }
     }
 
@@ -1808,11 +1810,13 @@ static void walk_field(java_ir* ir, definition* field_def, cfg_worker* field_ini
     }
     else
     {
+        operand = new_reference(IR_ASN_REF_LITERAL, def_li_null(ir));
+
         /**
          * otherwise we insert a dummy code, indicate that
          * the variable is defined here and some initialization required
         */
-        execute_irop_instruction(ir, field_init_worker, IROP_INIT, &lvalue, NULL, NULL);
+        execute_irop_instruction(ir, field_init_worker, IROP_ASN, &lvalue, &operand, NULL);
     }
 }
 

--- a/ir.h
+++ b/ir.h
@@ -19,6 +19,7 @@
 
 // some wrapper of def() variants
 #define def_li_dec32(ir, content) def_li_raw(ir, content, JLT_LTR_NUMBER, JT_NUM_DEC, JT_NUM_BIT_LENGTH_NORMAL)
+#define def_li_null(ir) def_li_raw(ir, "null", JLT_RWD_NULL, JT_NUM_MAX, JT_NUM_BIT_LENGTH_NORMAL)
 
 /**
  * def/use control bit flags

--- a/optimizer-heuristic-allocator.c
+++ b/optimizer-heuristic-allocator.c
@@ -1,10 +1,10 @@
 /**
  * Optimistic Allocator Heuristic
  *
- * TODO: read and based on:
- * https://groups.seas.harvard.edu/courses/cs153/2018fa/lectures/Lec20-Register-alloc-I.pdf
- * https://groups.seas.harvard.edu/courses/cs153/2018fa/lectures/Lec21-Register-alloc-II.pdf
- * https://www.cs.utexas.edu/users/mckinley/380C/lecs/12.pdf
+ * The allocator uses interference graph to find optimal use of
+ * registers, and spill the rest into memory
+ *
+ * This approach is considered to be expensive in general
 */
 
 #include "optimizer.h"


### PR DESCRIPTION
This PR deprecates `IROP_INIT` and uses `IROP_ASN` as a dummy initialization: `null` will be assigned to variable that does not have initializer upon declaration.