### PR TITLE
Finalize Linear Scan Register Allocation

### DIFF
--- a/main.c
+++ b/main.c
@@ -22,7 +22,8 @@ static char* test_paths[] = {
 
     // "./test/simple.txt",
     // "./test/il.txt",
-    "./test/ssa.txt",
+    // "./test/ssa.txt",
+    "./test/reg-alloc-1.txt",
 
     // "./test/general-no-block-and-statement.txt",
 

--- a/optimizer-defuse.c
+++ b/optimizer-defuse.c
@@ -15,7 +15,7 @@
 */
 void optimizer_defuse_analyze(optimizer* om)
 {
-    size_t num_nodes = om->graph->nodes.num;
+    size_t num_nodes = om->profile.num_nodes;
 
     for (size_t i = 0; i < om->profile.num_instructions; i++)
     {

--- a/optimizer-heuristic-allocator.c
+++ b/optimizer-heuristic-allocator.c
@@ -434,7 +434,7 @@ static float allocator_node_spill_cost(heuristic_allocator* allocator, size_t n)
  * WARNING: do NOT update allocator::om::profile because it is useful to safely release
  * old optimizer instance; use allocator::profile instead
 */
-void allocator_spill_code_read(heuristic_allocator* allocator, instruction* target, const variable_item* var_item)
+static void allocator_spill_code_read(heuristic_allocator* allocator, instruction* target, const variable_item* var_item)
 {
     definition* var = var_item->ref;
 
@@ -487,7 +487,7 @@ void allocator_spill_code_read(heuristic_allocator* allocator, instruction* targ
  * WARNING: do NOT update allocator::om::profile because it is useful to safely release
  * old optimizer instance; use allocator::profile instead
 */
-void allocator_spill_code_write(heuristic_allocator* allocator, instruction* target, const variable_item* var_item)
+static void allocator_spill_code_write(heuristic_allocator* allocator, instruction* target, const variable_item* var_item)
 {
     definition* var = var_item->ref;
 
@@ -512,6 +512,9 @@ void allocator_spill_code_write(heuristic_allocator* allocator, instruction* tar
 
 /**
  * Build Stage
+ *
+ * TODO: live-in AND live-out needed?
+ * (see: https://web.stanford.edu/class/archive/cs/cs143/cs143.1128/lectures/17/Slides17.pdf, page 130)
  *
  * Build inteference graph, and detect move-related variables
  * This stage is very expensive
@@ -845,7 +848,7 @@ static void optimizer_allocator_select(heuristic_allocator* allocator)
     // spill the variable
     if (allocator->state == ALLOCATOR_STATE_BUILD)
     {
-        size_t num_nodes = allocator->om->graph->nodes.num;
+        size_t num_nodes = allocator->om->profile.num_nodes;
         variable_item* var_spilled = &allocator->om->variables[varmap_lid2idx(allocator->om, frame->node)];
 
         // assign stack index, later in backend this index will be translated into offset

--- a/optimizer-liveness.c
+++ b/optimizer-liveness.c
@@ -1,7 +1,7 @@
 #include "optimizer.h"
 
 /**
- * TODO:Liveness Analysis
+ * Liveness Analysis
  *
  * It will fill the following data in optimizer object:
  * 1. in
@@ -14,14 +14,14 @@
  * out(n): union in(m), m is every successor of n
  * in(n): (out(n) - kill(n)) union gen(n)
  *
- * TODO:for def and use fill, we need to figure out how to handle
- * notes that is empty (hence no instruction)
- * => we can also create array map on nodes level for def and use
- * => anything simpler than this?
+ * NOTE:
+ * This algorithm works based on assumption that makes sure
+ * every node in CFG has at least one instruction. See
+ * optimizer_attach() on how it fulfills this assumption
 */
 void optimizer_liveness_analyze(optimizer* om)
 {
-    size_t num_nodes = om->graph->nodes.num;
+    size_t num_nodes = om->profile.num_nodes;
     size_t idx;
     index_set worklist;
 
@@ -55,6 +55,7 @@ void optimizer_liveness_analyze(optimizer* om)
         else
         {
             n = s->node;
+
             for (size_t i = 0; i < n->out.num; i++)
             {
                 index_set_union(live_out, &om->instructions[n->out.arr[i]->to->inst_first->id].in);
@@ -78,7 +79,7 @@ void optimizer_liveness_analyze(optimizer* om)
             else
             {
                 n = s->node;
-                for (size_t i = 0; i < n->out.num; i++)
+                for (size_t i = 0; i < n->in.num; i++)
                 {
                     index_set_add(&worklist, n->in.arr[i]->from->inst_last->id);
                 }

--- a/optimizer-util.c
+++ b/optimizer-util.c
@@ -176,7 +176,7 @@ void optimizer_populate_variables(optimizer* om)
     om->variables = (variable_item*)malloc_assert(sz_variables);
     memset(om->variables, 0, sz_variables);
 
-    for (size_t i = 0; i < om->graph->nodes.num; i++)
+    for (size_t i = 0; i < om->profile.num_nodes; i++)
     {
         basic_block* bb = om->graph->nodes.arr[i];
 
@@ -202,7 +202,7 @@ void optimizer_populate_variables(optimizer* om)
 */
 void optimizer_populate_instructions(optimizer* om)
 {
-    size_t num_nodes = om->graph->nodes.num;
+    size_t num_nodes = om->profile.num_nodes;
     size_t sz_instructions = sizeof(instruction_item) * om->profile.num_instructions;
 
     om->instructions = (instruction_item*)malloc_assert(sz_instructions);

--- a/optimizer.h
+++ b/optimizer.h
@@ -6,8 +6,16 @@
 #include "ir.h"
 #include "index-set.h"
 
+/**
+ * Variable Allocation Type
+ *
+ * VAR_ALLOC_UNDEFINED:
+ * when a variable is detected by optimizer such that it can be optimized out
+ * somehow, then allocation info is undefined
+*/
 typedef enum _variable_allocation_type
 {
+    VAR_ALLOC_UNDEFINED = 0,
     VAR_ALLOC_REGISTER,
     VAR_ALLOC_STACK,
 } variable_allocation_type;
@@ -32,6 +40,7 @@ typedef struct _instruction_item
 
 typedef struct _optimizer_profile
 {
+    size_t num_nodes;
     size_t num_members;
     size_t num_locals;
     size_t num_variables;
@@ -103,9 +112,9 @@ void optimizer_profile_copy(optimizer* om, optimizer_profile* profile);
 void optimizer_profile_apply(optimizer* om, optimizer_profile* profile);
 
 void optimizer_defuse_analyze(optimizer* om);
+void optimizer_liveness_analyze(optimizer* om);
 void optimizer_ssa_build(optimizer* om);
 void optimizer_ssa_eliminate(optimizer* om);
-void optimizer_liveness_analyze(optimizer* om);
 void optimizer_allocator_heuristic(optimizer* om, size_t num_avail_registers);
 void optimizer_allocator_linear(optimizer* om, size_t num_avail_registers);
 

--- a/test/reg-alloc-1.txt
+++ b/test/reg-alloc-1.txt
@@ -1,0 +1,28 @@
+// example: https://web.stanford.edu/class/archive/cs/cs143/cs143.1128/lectures/17/Slides17.pdf, page 64
+// 4-register linear allocation result should match page 79 (ignore temp vars, match reg number to each color)
+class LinearAllocatorTest
+{
+    void allocator()
+    {
+        int a,b,c,d,e,f,g;
+
+        e = d + a;
+        f = b + c;
+        f = f + b;
+
+        if (e == 0)
+        {
+            d = e - f;
+        }
+        else
+        {
+            d = e + f;
+        }
+
+        g = d;
+
+        // this is inserted to "use" variable "g"
+        // comment this to see "unused variable warning"
+        return g;
+    }
+}


### PR DESCRIPTION
This PR includes critical bugfix for linear-scan register allocation algorithm.

* Fixed `index_set` initialization bug: upper bound was not respected during filling and initializer incorrectly filled unused bits in set and cause incorrect set data
* Update `IROP_TEST` instruction form: now this instruction must have one operand as "test against". This update is very important for optimizer to yield correct analysis facts; liveness, for example, needs every variable to be referenced in places explicitly
* Fixed a bug in liveness analysis: worklist mutation used incorrect node set: it should use predecessor set, but logic uses successor ones
* Fixed a bug in SSA builder: `index_set_contains` relies on valid user-defined variable index, but the logic exposed the interface to invalid indices and it will cause function to crash
* Added a assuption in optimizer initialization: it will make sure that every node in CFG will have at least one instruction before any work. If the node is empty, the optimizer will insert a dummy instruction `IROP_NOOP`. This is important to build clean algorithms like liveness analysis because those algorithms need to access neighbors (successor/predecessor) of an instruction, and this instruction will guarantee that any instruction in CFG will always have valid neighbors in both directions
* Fixed critical bugs in linear scan algorithm: merge sort bug, insufficient allocator data initializations, incorrect memory release logic
* Added test case, and passed