### PR TITLE
Finalize Interference Graph Register Allocator

### DIFF
--- a/main.c
+++ b/main.c
@@ -23,7 +23,8 @@ static char* test_paths[] = {
     // "./test/simple.txt",
     // "./test/il.txt",
     // "./test/ssa.txt",
-    "./test/reg-alloc-1.txt",
+    // "./test/reg-alloc-1.txt",
+    "./test/reg-alloc-2.txt",
 
     // "./test/general-no-block-and-statement.txt",
 

--- a/optimizer-linear-allocator.c
+++ b/optimizer-linear-allocator.c
@@ -79,11 +79,11 @@ typedef struct _linear_scan_allocator
 
 static void __debug_print_interval(const live_interval* interval)
 {
-    printf("(%zd, %zd), %s, active order: %zd, alloc: %zd\n",
+    printf("(%zd, %zd), active order: %zd, alloc: %c%zd\n",
         interval->start,
         interval->end,
-        interval->spilled ? "spilled" : "not spilled",
         interval->active_order,
+        interval->spilled ? 's' : 'r',
         interval->spilled ? interval->alloc.stack : interval->alloc.reg
     );
 }
@@ -435,10 +435,7 @@ static void init_linear_scan_allocator(optimizer* om, linear_scan_allocator* all
     // fill intervals
     for (size_t i = 0; i < om->profile.num_instructions; i++)
     {
-        /**
-         * TODO: need live-in?
-        */
-        // live_set_to_interval(allocator, &om->instructions[i].in, i);
+        live_set_to_interval(allocator, &om->instructions[i].in, i);
         live_set_to_interval(allocator, &om->instructions[i].out, i);
     }
 

--- a/optimizer.c
+++ b/optimizer.c
@@ -137,6 +137,6 @@ void optimizer_execute(optimizer* om)
     optimizer_ssa_eliminate(om);
 
     // register allocation
-    // optimizer_allocator_heuristic(om, 4);
-    optimizer_allocator_linear(om, 4);
+    optimizer_allocator_heuristic(om, 4);
+    // optimizer_allocator_linear(om, 4);
 }

--- a/test/reg-alloc-1.txt
+++ b/test/reg-alloc-1.txt
@@ -1,7 +1,9 @@
 // example: https://web.stanford.edu/class/archive/cs/cs143/cs143.1128/lectures/17/Slides17.pdf, page 64
-// 4-register linear allocation result should match page 79 (ignore temp vars, match reg number to each color)
-class LinearAllocatorTest
+class RegisterAllocatorTest
 {
+    short m1, m2;
+    int n3;
+
     void allocator()
     {
         int a,b,c,d,e,f,g;

--- a/test/reg-alloc-2.txt
+++ b/test/reg-alloc-2.txt
@@ -1,0 +1,23 @@
+// example: https://groups.seas.harvard.edu/courses/cs153/2019fa/lectures/Lec22-Reg-alloc-ctd.pdf, page 28
+class RegisterAllocatorTest
+{
+    void allocator(int b, int c, int d, int e, int f, int g, int h, int m)
+    {
+        int j,k;
+
+        g = j + 12;
+        h = k - 1;
+        f = g * h;
+        e = j + 8;
+        m = j + 16;
+        b = f + 0;
+        c = e + 8;
+        d = c;
+        k = m + 4;
+        j = b;
+
+        // this is inserted to "use" variables
+        // comment this to see "unused variable warning"
+        return d + j + k;
+    }
+}


### PR DESCRIPTION
This PR fixes critical bugs and refactors logic in interference graph register allocator.

* Used both live-in and live-out sets during initialization of register allocation algorithms (including linear version)
* Added debug output for interference graph
* Refactored node coloring logic